### PR TITLE
feat: add post-training for multiview diffusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ For the complete step-by-step pipeline walkthrough — from raw NCore driving lo
 
 </details>
 
+<details>
+<summary><b>Post-Training (Fine-Tuning)</b></summary>
+
+The SparseViewDiT multiview diffusion model can be fine-tuned on your own parsed samples with the same rectified-flow objective it was pretrained with, built on HuggingFace `diffusers` + `accelerate` (full fine-tuning or LoRA, single- or multi-GPU). See the **[Post-Training Guide](docs/post_training.md)**.
+
+</details>
+
 
 <a id="benchmark"></a>
 <details>

--- a/asset_harvester/multiview_diffusion/configs/__init__.py
+++ b/asset_harvester/multiview_diffusion/configs/__init__.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unified SparseViewDiT configuration: model architecture + training defaults.
+
+``sparseviewdit_512.yaml`` in this package is the checked-in source of truth
+for the released checkpoint. ``load_unified_config`` reads it (or a
+user-supplied override file) and validates its structure.
+"""
+
+from pathlib import Path
+
+import yaml
+
+DEFAULT_CONFIG_PATH = Path(__file__).parent / "sparseviewdit_512.yaml"
+
+_REQUIRED_SECTIONS = ("model", "training")
+
+
+def load_unified_config(path: str | Path | None = None) -> dict:
+    """Load a unified config YAML with ``model`` and ``training`` sections.
+
+    ``path=None`` loads the packaged default (the released 512px checkpoint's
+    configuration).
+    """
+    config_path = Path(path) if path is not None else DEFAULT_CONFIG_PATH
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+    if not isinstance(config, dict):
+        raise ValueError(f"Config must be a mapping with sections {_REQUIRED_SECTIONS}: {config_path}")
+    for section in _REQUIRED_SECTIONS:
+        if not isinstance(config.get(section), dict):
+            raise ValueError(f"Config is missing the '{section}' section: {config_path}")
+    return config

--- a/asset_harvester/multiview_diffusion/configs/sparseviewdit_512.yaml
+++ b/asset_harvester/multiview_diffusion/configs/sparseviewdit_512.yaml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unified SparseViewDiT configuration — the source of truth for the released
+# 512px checkpoint (AH_multiview_diffusion.safetensors).
+#
+# - `model`: transformer architecture. Used by inference (model_builder) and by
+#   post-training when starting from the released single-file checkpoint. When
+#   training resumes from a diffusers-format directory, that directory's
+#   config.json takes precedence.
+# - `training`: default post-training hyperparameters. train.py loads these as
+#   argparse defaults; any command-line flag overrides the value here. Pass a
+#   customized copy via `--config /path/to/my.yaml`.
+#
+# Run-specific paths (--data_root, --output_dir, --checkpoint_path, ...) are
+# deliberately not part of this file.
+
+model:
+  in_channels: 32              # DC-AE latent channels (rays/mask widen the input conv internally)
+  out_channels: 32
+  num_attention_heads: 70      # 70 * 32 = 2240 hidden dim
+  attention_head_dim: 32
+  num_layers: 20
+  num_cross_attention_heads: 20
+  cross_attention_head_dim: 112  # 20 * 112 = 2240
+  cross_attention_dim: 2240
+  caption_channels: 1280       # C-RADIO feature dim
+  mlp_ratio: 2.5
+  patch_size: 1
+  sample_size: 16              # 16 * 32 (VAE downsample) = 512 px
+  camera_emb: true
+  camera_emb_dim: 17           # flattened relative c2w (16) + fov (1)
+  brightness_emb: true
+  cond_on_rays: true           # concat 6-ch Plucker rays to the input
+  cond_on_mask: true           # concat 1-ch conditioning mask to the input
+
+training:
+  # Data / preprocessing
+  resolution: 512
+  max_views: 16
+  conditioning_min_n: 0        # 0 supplies unconditional samples for CFG
+  conditioning_max_n: 4
+  symmetry_aug_p: 0.4
+  dataset_repeats: 1
+  dataloader_num_workers: 4
+
+  # Model options
+  gradient_checkpointing: false
+  lora_rank: 0                 # 0 trains all parameters
+  lora_alpha: null             # defaults to lora_rank
+
+  # Flow matching (matches pretraining)
+  num_train_timesteps: 1000
+  flow_shift: 1.0              # 1.0 at 512px; 3-4 at 1024px
+  weighting_scheme: logit_normal
+  logit_mean: 0.0
+  logit_std: 1.0
+  cfg_dropout_prob: 0.1
+
+  # Optimization
+  train_batch_size: 1          # objects (not views) per device
+  max_train_steps: 10000
+  gradient_accumulation_steps: 1
+  learning_rate: 1.0e-5
+  lr_scheduler: constant_with_warmup
+  lr_warmup_steps: 200
+  adam_beta1: 0.9
+  adam_beta2: 0.999
+  adam_weight_decay: 0.0
+  adam_epsilon: 1.0e-8
+  use_8bit_adam: false
+  max_grad_norm: 0.1
+  mixed_precision: bf16
+  use_ema: false
+  ema_decay: 0.9999
+
+  # Checkpointing / logging / validation
+  seed: 42
+  checkpointing_steps: 500
+  checkpoints_total_limit: null
+  validation_steps: 250
+  num_validation_samples: 2
+  validation_inference_steps: 30
+  validation_guidance_scale: 2.0
+  report_to: tensorboard
+  tracker_project_name: sparseviewdit-post-training
+  log_interval: 10

--- a/asset_harvester/multiview_diffusion/data/sample_loading.py
+++ b/asset_harvester/multiview_diffusion/data/sample_loading.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Loading of ncore-parser (or compatible) multiview sample directories into MVData.
+
+A sample directory contains ``input_views/`` with ``camera.json``, ``frame_*``
+images, and ``mask_*`` images. Used by both inference (run_inference.py) and
+post-training (training/dataset.py).
+"""
+
+import json
+import os
+
+import numpy as np
+from PIL import Image
+
+from .nre_preproc import MVData
+
+
+def load_camera_metadata(input_dir: str) -> dict:
+    """Load canonical camera metadata from input_views/camera.json."""
+    camera_path = os.path.join(input_dir, "camera.json")
+    if not os.path.isfile(camera_path):
+        raise FileNotFoundError(f"Missing camera.json in {input_dir}")
+
+    with open(camera_path) as f:
+        return json.load(f)
+
+
+def get_camera_file_paths(input_dir: str, cam_data: dict) -> tuple[list[str], list[str]]:
+    """Resolve ordered frame and mask file paths from camera metadata."""
+    frame_paths = [os.path.join(input_dir, filename) for filename in cam_data.get("frame_filenames", [])]
+    mask_paths = [os.path.join(input_dir, filename) for filename in cam_data.get("mask_filenames", [])]
+    return frame_paths, mask_paths
+
+
+def load_multiview_sample(sample_dir: str, allowed_indices: list[int] | None = None) -> MVData:
+    """
+    Load one sample from a ncore_parser (or compatible) output directory into an MVData instance
+    for use with preproc. Uses input_views only (frames, masks, camera.json).
+    """
+    input_dir = os.path.join(sample_dir, "input_views")
+    if not os.path.isdir(input_dir):
+        raise FileNotFoundError(f"Missing input_views: {input_dir}")
+
+    cam_data = load_camera_metadata(input_dir)
+    frame_filenames_all = cam_data["frame_filenames"]
+    frame_paths_all, mask_paths_all = get_camera_file_paths(input_dir, cam_data)
+    cam_poses_raw_all = cam_data["normalized_cam_positions"]
+    dists_list_all = cam_data["cam_dists"]
+    fov_list_all = cam_data["cam_fovs"]
+    lwh_list = cam_data["object_lwh"]
+
+    if allowed_indices is None:
+        allowed_indices = list(range(len(frame_filenames_all)))
+
+    frame_filenames = [frame_filenames_all[i] for i in allowed_indices]
+    frame_paths = [frame_paths_all[i] for i in allowed_indices]
+    mask_paths = [mask_paths_all[i] for i in allowed_indices]
+    cam_poses_raw = [cam_poses_raw_all[i] for i in allowed_indices]
+    dists_list = [dists_list_all[i] for i in allowed_indices]
+    fov_list = [fov_list_all[i] for i in allowed_indices]
+
+    n = len(frame_filenames)
+    if n == 0:
+        raise ValueError(f"No input views in {sample_dir}")
+
+    frames = []
+    masks = []
+    for path in frame_paths:
+        img = Image.open(path).convert("RGB")
+        frames.append(np.array(img))
+    for path in mask_paths:
+        mask_img = Image.open(path)
+        mask = np.array(mask_img)
+        if mask.ndim == 3:
+            mask = mask[:, :, 0]
+        masks.append(mask)
+
+    # cam_poses: (N, 3) camera positions
+    cam_poses = np.array(cam_poses_raw, dtype=np.float64).reshape(n, 3)
+
+    dists = np.array(dists_list, dtype=np.float64).reshape(n)
+    fov = np.array(fov_list, dtype=np.float64).reshape(n)
+    lwh = np.asarray(lwh_list, dtype=np.float64).reshape(3)
+
+    metadata_path = os.path.join(sample_dir, "metadata.json")
+    if os.path.isfile(metadata_path):
+        with open(metadata_path) as f:
+            meta = json.load(f)
+        clip_id = meta.get("clip_id", os.path.basename(sample_dir))
+    else:
+        clip_id = os.path.basename(sample_dir)
+    obj_id = os.path.basename(sample_dir)
+
+    return MVData(
+        clip_id=clip_id,
+        obj_id=obj_id,
+        frames=frames,
+        cam_poses=cam_poses,
+        dists=dists,
+        fov=fov,
+        npct="vehicle",
+        lwh=lwh,
+        masks=np.array(masks),
+        auto_label=None,
+    )
+
+
+def discover_sample_dirs(data_root: str) -> list[str]:
+    """Find all sample directories (containing input_views/camera.json) under data_root."""
+    sample_dirs = []
+    for dirpath, dirnames, _filenames in os.walk(data_root, followlinks=True):
+        if os.path.isfile(os.path.join(dirpath, "input_views", "camera.json")):
+            sample_dirs.append(dirpath)
+            dirnames.clear()  # don't descend into a sample
+    return sorted(sample_dirs)

--- a/asset_harvester/multiview_diffusion/models/sparseviewdit.py
+++ b/asset_harvester/multiview_diffusion/models/sparseviewdit.py
@@ -548,6 +548,11 @@ class SparseViewDiTTransformer2DModelNative(SanaTransformer2DModel):
             timestep_scale=timestep_scale,
         )
 
+        # super().__init__ re-registered the ray/mask-widened conv width as
+        # in_channels; restore the logical latent channel count so that
+        # save_pretrained -> from_pretrained does not widen the input twice.
+        self.register_to_config(in_channels=in_channels)
+
         inner_dim = num_attention_heads * attention_head_dim
 
         # Replace transformer_blocks with multiview-aware blocks

--- a/asset_harvester/multiview_diffusion/training/__init__.py
+++ b/asset_harvester/multiview_diffusion/training/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rectified-flow post-training for the SparseViewDiT multiview diffusion model."""
+
+from .flow_match import (
+    RectifiedFlowSchedule,
+    broadcast_to_views,
+    flow_matching_loss,
+    velocity_target,
+)
+
+__all__ = [
+    "RectifiedFlowSchedule",
+    "broadcast_to_views",
+    "flow_matching_loss",
+    "velocity_target",
+]

--- a/asset_harvester/multiview_diffusion/training/cond_processor.py
+++ b/asset_harvester/multiview_diffusion/training/cond_processor.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Training-time conditioning processor for SparseViewDiT.
+
+Turns a list of preproc'd objects (variable view counts) into the flattened
+tensors the transformer's forward expects, mirroring the tensor assembly of
+``SparseViewDiTPipeline.prepare_multiview_inputs`` at inference:
+
+- VAE-encode all views (fp32 VAE, scaled by the DC-AE scaling factor)
+- downsample Plucker rays to the latent resolution
+- per-view conditioning mask (targets first: 0, conditioning views: 1)
+- camera embedding = flattened relative c2w (16) + fov (1)
+- C-RADIO image embedding of the conditioning views (max-pooled over views),
+  replaced by the null (grey image) embedding with probability
+  ``cfg_dropout_prob`` — and always when an object has 0 conditioning views —
+  to support classifier-free guidance.
+"""
+
+import math
+
+import numpy as np
+import torch
+from PIL import Image
+from torchvision.transforms.functional import resize as torch_resize
+
+_VAE_MINIBATCH_SIZE = 16
+_DEFAULT_SCALING_FACTOR = 0.41407
+
+
+class MultiviewCondProcessor:
+    def __init__(
+        self,
+        vae,
+        image_encoder,
+        image_processor,
+        weight_dtype: torch.dtype = torch.bfloat16,
+        cfg_dropout_prob: float = 0.1,
+    ):
+        self.vae = vae
+        self.image_encoder = image_encoder
+        self.image_processor = image_processor
+        self.weight_dtype = weight_dtype
+        self.cfg_dropout_prob = cfg_dropout_prob
+        self._null_embed: torch.Tensor | None = None
+
+        if getattr(vae.config, "scaling_factor", None):
+            self.scaling_factor = vae.config.scaling_factor
+        else:
+            self.scaling_factor = _DEFAULT_SCALING_FACTOR
+
+    @torch.no_grad()
+    def _encode_latents(self, images: torch.Tensor) -> torch.Tensor:
+        """VAE-encode [N, 3, H, W] images in minibatches; returns scaled latents."""
+        chunks = []
+        for i in range(math.ceil(images.shape[0] / _VAE_MINIBATCH_SIZE)):
+            batch = images[i * _VAE_MINIBATCH_SIZE : (i + 1) * _VAE_MINIBATCH_SIZE]
+            z = self.vae.encode(batch.to(self.vae.device, dtype=self.vae.dtype))
+            if hasattr(z, "latent"):
+                z = z.latent
+            chunks.append(z * self.scaling_factor)
+        return torch.cat(chunks, dim=0)
+
+    @torch.no_grad()
+    def _encode_image_prompt(self, cond_images: torch.Tensor, device: torch.device) -> torch.Tensor:
+        """C-RADIO embed conditioning images ([-1, 1] tensors), max-pooled over views."""
+        pil_images = []
+        for img in cond_images:
+            img_np = ((img + 1.0) / 2.0 * 255).clamp(0, 255).permute(1, 2, 0).to(torch.uint8).cpu().numpy()
+            pil_images.append(Image.fromarray(img_np))
+        pixel_values = self.image_processor(images=pil_images, return_tensors="pt", do_resize=True).pixel_values
+        _summary, features = self.image_encoder(pixel_values.to(device))
+        return torch.amax(features, dim=0, keepdim=True)  # [1, tokens, dim]
+
+    @torch.no_grad()
+    def null_image_prompt(self, device: torch.device) -> torch.Tensor:
+        """Embedding of a grey image — the CFG unconditional prompt (cached)."""
+        if self._null_embed is None:
+            grey = torch.zeros(1, 3, 512, 512)  # 0.0 in [-1, 1] == pixel value 128
+            self._null_embed = self._encode_image_prompt(grey, device)
+        return self._null_embed
+
+    @torch.no_grad()
+    def __call__(self, objects: list, device: torch.device, generator: torch.Generator | None = None) -> dict:
+        """Encode a batch (list) of preproc'd objects into flattened model inputs.
+
+        Returns a dict with per-view tensors concatenated across objects
+        (``clean_latents``, ``rays``, ``cond_mask``, ``camera_emb``,
+        ``relative_brightness``), per-object ``prompt_embeds`` and
+        ``views_per_object``/``n_targets`` bookkeeping.
+        """
+        clean_latents, rays, cond_masks, camera_embs, brightness, prompts = [], [], [], [], [], []
+        views_per_object, n_targets = [], []
+
+        for obj in objects:
+            n_views = obj.x.shape[0]
+            n_target = obj.n_target
+            n_cond = n_views - n_target
+
+            z = self._encode_latents(obj.x)
+            latent_size = z.shape[-1]
+            ray = torch_resize(obj.plucker_image.to(device, dtype=torch.float32), latent_size)
+
+            mask = torch.zeros(n_views, z.shape[1], latent_size, latent_size, device=device)
+            mask[n_target:] = 1.0
+
+            cam = torch.cat(
+                [obj.c2w_relatives.reshape(-1, 16), obj.fovs.unsqueeze(-1)],
+                dim=-1,
+            ).to(device)
+
+            bright = obj.relative_brightness.to(device)
+            if bright.dim() == 1:
+                bright = bright.unsqueeze(-1)
+
+            drop = torch.rand((), generator=generator).item() < self.cfg_dropout_prob
+            if n_cond == 0 or drop:
+                prompt = self.null_image_prompt(device)
+            else:
+                prompt = self._encode_image_prompt(obj.x_white_background[n_target:], device)
+
+            clean_latents.append(z.to(device))
+            rays.append(ray)
+            cond_masks.append(mask)
+            camera_embs.append(cam)
+            brightness.append(bright)
+            prompts.append(prompt)
+            views_per_object.append(n_views)
+            n_targets.append(n_target)
+
+        dt = self.weight_dtype
+        return {
+            "clean_latents": torch.cat(clean_latents, dim=0).to(dt),
+            "rays": torch.cat(rays, dim=0).to(dt),
+            "cond_mask": torch.cat(cond_masks, dim=0).to(dt),
+            "camera_emb": torch.cat(camera_embs, dim=0).to(dt),
+            "relative_brightness": torch.cat(brightness, dim=0).to(dt),
+            "prompt_embeds": torch.cat(prompts, dim=0).to(dt),  # [num_objects, tokens, dim]
+            "views_per_object": views_per_object,
+            "n_targets": n_targets,
+        }
+
+
+def make_validation_grid(images: list, views_per_row: int) -> np.ndarray:
+    """Stack a flat list of PIL images into an HWC uint8 grid, one object per row."""
+    rows = []
+    for i in range(0, len(images), views_per_row):
+        row = np.concatenate([np.asarray(im) for im in images[i : i + views_per_row]], axis=1)
+        rows.append(row)
+    width = max(r.shape[1] for r in rows)
+    rows = [np.pad(r, ((0, 0), (0, width - r.shape[1]), (0, 0))) for r in rows]
+    return np.concatenate(rows, axis=0)

--- a/asset_harvester/multiview_diffusion/training/dataset.py
+++ b/asset_harvester/multiview_diffusion/training/dataset.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Training dataset over ncore-parser sample directories.
+
+Each item is one object: the multiview sample is loaded from disk and run
+through the same ``preproc`` used at inference, but in training mode
+(``eval_mode=False``): a random subset of views becomes conditioning
+(``random_n`` between ``conditioning_min_n`` and ``conditioning_max_n``,
+0 supplying the unconditional case for CFG) and the rest become denoising
+targets with their real images kept as ground truth. Target views come first
+in every per-view tensor, conditioning views after.
+
+Objects have variable view counts, so batches are plain lists of per-object
+AttrDicts (``collate_objects``); flattening into model inputs happens in
+``MultiviewCondProcessor``.
+"""
+
+import os
+import random
+import warnings
+from functools import partial
+
+import torch
+import torchvision.transforms as T
+from torch.utils.data import Dataset
+
+from ..data.nre_preproc import preproc
+from ..data.sample_loading import discover_sample_dirs, load_camera_metadata, load_multiview_sample
+
+
+def _count_views(sample_dir: str) -> int:
+    """Number of views in a sample, from camera.json alone (no image reads)."""
+    try:
+        cam_data = load_camera_metadata(os.path.join(sample_dir, "input_views"))
+        return len(cam_data.get("frame_filenames", []))
+    except Exception:
+        return 0
+
+
+class MultiviewObjectDataset(Dataset):
+    """Map-style dataset: one ncore-parser sample directory per item.
+
+    Defaults mirror the released checkpoint's training configuration
+    (512 px, up to 16 views, 0-4 conditioning views, symmetry augmentation,
+    white-masked target backgrounds).
+    """
+
+    def __init__(
+        self,
+        data_root: str | None = None,
+        sample_dirs: list[str] | None = None,
+        resolution: int = 512,
+        max_views: int = 16,
+        conditioning_mode: str = "random_n",
+        conditioning_min_n: int = 0,
+        conditioning_max_n: int = 4,
+        symmetry_aug_p: float = 0.4,
+        mask_out_background_target: bool | str = "white",
+        mask_out_background_cond: bool | str = False,
+        plucker_scene_scale: float = 30.0,
+        repeats: int = 1,
+        max_load_retries: int = 4,
+    ):
+        if (data_root is None) == (sample_dirs is None):
+            raise ValueError("Provide exactly one of data_root or sample_dirs")
+        candidates = sample_dirs if sample_dirs is not None else discover_sample_dirs(data_root)
+        if not candidates:
+            raise ValueError(f"No sample directories with input_views/camera.json found under {data_root}")
+        # Training needs >= 2 views per object (>= 1 conditioning + >= 1 target).
+        self.sample_dirs = [d for d in candidates if _count_views(d) >= 2]
+        dropped = len(candidates) - len(self.sample_dirs)
+        if dropped:
+            warnings.warn(f"Dropped {dropped}/{len(candidates)} samples with fewer than 2 views", stacklevel=2)
+        if not self.sample_dirs:
+            raise ValueError("No usable samples: all have fewer than 2 views")
+        self.repeats = repeats
+        self.max_load_retries = max_load_retries
+
+        image_transform = T.Compose(
+            [
+                T.Resize(resolution),
+                T.ToTensor(),
+                T.Normalize([0.5], [0.5]),
+            ]
+        )
+        self._preproc = partial(
+            preproc,
+            image_transform=image_transform,
+            resolution=resolution,
+            max_views=max_views,
+            conditioning_mode=conditioning_mode,
+            conditioning_min_n=conditioning_min_n,
+            conditioning_max_n=conditioning_max_n,
+            symmetry_aug_p=symmetry_aug_p,
+            mask_out_background_target=mask_out_background_target,
+            mask_out_background_cond=mask_out_background_cond,
+            plucker_scene_scale=plucker_scene_scale,
+            eval_mode=False,
+        )
+
+    def __len__(self) -> int:
+        return len(self.sample_dirs) * self.repeats
+
+    def __getitem__(self, index: int):
+        idx = index % len(self.sample_dirs)
+        for attempt in range(self.max_load_retries + 1):
+            sample_dir = self.sample_dirs[idx]
+            try:
+                item = load_multiview_sample(sample_dir)
+                return self._preproc(item)
+            except Exception as e:  # corrupt sample: fall back to a random other one
+                if attempt == self.max_load_retries or len(self.sample_dirs) == 1:
+                    raise RuntimeError(f"Failed to load sample after retries: {sample_dir}") from e
+                warnings.warn(f"Skipping unloadable sample {sample_dir}: {e}", stacklevel=2)
+                idx = random.choice([i for i in range(len(self.sample_dirs)) if i != idx])
+        raise AssertionError("unreachable")
+
+
+def collate_objects(batch: list) -> list:
+    """Objects have variable view counts; keep the batch as a list of AttrDicts."""
+    return list(batch)
+
+
+def build_dataloader(
+    dataset: Dataset,
+    batch_size: int,
+    num_workers: int = 4,
+    shuffle: bool = True,
+    seed: int | None = None,
+) -> torch.utils.data.DataLoader:
+    """DataLoader over objects; ``batch_size`` counts objects, not views."""
+    generator = None
+    if seed is not None:
+        generator = torch.Generator()
+        generator.manual_seed(seed)
+    return torch.utils.data.DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=shuffle,
+        num_workers=num_workers,
+        collate_fn=collate_objects,
+        generator=generator,
+        drop_last=True,
+        persistent_workers=num_workers > 0,
+    )

--- a/asset_harvester/multiview_diffusion/training/flow_match.py
+++ b/asset_harvester/multiview_diffusion/training/flow_match.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Rectified-flow (flow matching) training utilities for SparseViewDiT.
+
+Implements the training-time noising process the released checkpoint was trained
+with: a "linear_flow" sigma schedule with an optional resolution-dependent
+timestep shift, logit-normal timestep sampling (SD3-style), linear interpolation
+noising, and a velocity prediction target:
+
+    sigma_t' = shift * sigma_t / (1 + (shift - 1) * sigma_t)
+    x_t      = (1 - sigma_t') * x0 + sigma_t' * eps
+    target   = eps - x0
+
+The model consumes a continuous timestep ``sigma_t' * num_train_timesteps``,
+matching the flow-sigma convention used by ``DPMSolverMultistepScheduler``
+(``use_flow_sigmas=True``) at inference.
+"""
+
+import numpy as np
+import torch
+
+
+class RectifiedFlowSchedule:
+    """Training-time sigma schedule for rectified-flow fine-tuning.
+
+    The base schedule is ``sigma_i = 1 - beta_i`` with ``beta`` linearly spaced
+    from 1.0 to 0.001 over ``num_train_timesteps`` steps, so ``sigma`` ascends
+    from 0.0 to 0.999. ``flow_shift`` (> 1 for higher resolutions) warps sigmas
+    toward the noisy end; 1.0 is the identity and the correct value at 512 px.
+    """
+
+    def __init__(self, num_train_timesteps: int = 1000, flow_shift: float = 1.0):
+        if num_train_timesteps < 2:
+            raise ValueError(f"num_train_timesteps must be >= 2, got {num_train_timesteps}")
+        if flow_shift <= 0:
+            raise ValueError(f"flow_shift must be positive, got {flow_shift}")
+        self.num_train_timesteps = num_train_timesteps
+        self.flow_shift = flow_shift
+
+        scale = 1000.0 / num_train_timesteps
+        betas = np.linspace(scale * 1.0, scale * 0.001, num_train_timesteps, dtype=np.float64)
+        sigmas = 1.0 - betas
+        sigmas = flow_shift * sigmas / (1.0 + (flow_shift - 1.0) * sigmas)
+
+        self.sigmas = torch.from_numpy(sigmas)
+        # Continuous timestep fed to the model (flow-sigma convention).
+        self.timesteps = self.sigmas * num_train_timesteps
+
+    def sample_timestep_indices(
+        self,
+        batch_size: int,
+        weighting_scheme: str = "logit_normal",
+        logit_mean: float = 0.0,
+        logit_std: float = 1.0,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        """Sample per-sample timestep indices in ``[0, num_train_timesteps)``.
+
+        ``logit_normal`` draws ``u = sigmoid(N(logit_mean, logit_std))`` (SD3
+        section 3.1) and maps it to an index; ``uniform`` draws indices directly.
+        """
+        if weighting_scheme == "logit_normal":
+            u = torch.normal(mean=logit_mean, std=logit_std, size=(batch_size,), device="cpu", generator=generator)
+            u = torch.sigmoid(u)
+            indices = (u * self.num_train_timesteps).long()
+        elif weighting_scheme == "uniform":
+            indices = torch.randint(0, self.num_train_timesteps, (batch_size,), generator=generator)
+        else:
+            raise ValueError(f"Unknown weighting_scheme: {weighting_scheme}")
+        return indices.clamp_(max=self.num_train_timesteps - 1)
+
+    def add_noise(
+        self, x0: torch.Tensor, noise: torch.Tensor, timestep_indices: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Noise clean latents: ``x_t = (1 - sigma) * x0 + sigma * eps``.
+
+        ``timestep_indices`` has one entry per item in ``x0``'s batch dim.
+        Returns ``(x_t, model_timesteps)`` where ``model_timesteps`` is the
+        continuous timestep tensor to feed the transformer.
+        """
+        if timestep_indices.shape[0] != x0.shape[0]:
+            raise ValueError(
+                f"timestep_indices batch ({timestep_indices.shape[0]}) != x0 batch ({x0.shape[0]}); "
+                "broadcast per-object indices across views first (see broadcast_to_views)"
+            )
+        sigmas = self.sigmas.to(device=x0.device, dtype=x0.dtype)[timestep_indices.to(x0.device)]
+        sigmas = sigmas.reshape(-1, *([1] * (x0.ndim - 1)))
+        x_t = (1.0 - sigmas) * x0 + sigmas * noise
+        model_timesteps = self.timesteps.to(x0.device)[timestep_indices.to(x0.device)].to(x0.dtype)
+        return x_t, model_timesteps
+
+
+def broadcast_to_views(per_object: torch.Tensor, views_per_object: list[int]) -> torch.Tensor:
+    """Repeat one value per object across that object's views.
+
+    All views of an object share a timestep during training; this expands a
+    ``(num_objects,)`` tensor to ``(sum(views_per_object),)``.
+    """
+    if per_object.shape[0] != len(views_per_object):
+        raise ValueError(f"got {per_object.shape[0]} values for {len(views_per_object)} objects")
+    repeats = torch.tensor(views_per_object, device=per_object.device)
+    return torch.repeat_interleave(per_object, repeats, dim=0)
+
+
+def velocity_target(x0: torch.Tensor, noise: torch.Tensor) -> torch.Tensor:
+    """Rectified-flow velocity target ``v = eps - x0`` (points from data to noise)."""
+    return noise - x0
+
+
+def flow_matching_loss(
+    model_output: torch.Tensor, target: torch.Tensor, cond_mask: torch.Tensor | None = None
+) -> torch.Tensor:
+    """Velocity MSE averaged per view, then over all views.
+
+    Conditioning views (``cond_mask == 1``) are excluded from the numerator but
+    kept in the denominator: the model output on those views is the pasted-back
+    clean latent, which carries no gradient, so this matches the gradients of an
+    unmasked mean over all views while reporting a loss free of the constant
+    conditioning-view residual.
+    """
+    per_view = (model_output.float() - target.float()) ** 2
+    per_view = per_view.mean(dim=tuple(range(1, per_view.ndim)))
+    if cond_mask is None:
+        return per_view.mean()
+    # cond_mask is constant within a view; reduce to one weight per view.
+    target_weight = 1.0 - cond_mask.reshape(cond_mask.shape[0], -1).amax(dim=1).float()
+    return (per_view * target_weight).sum() / per_view.shape[0]

--- a/asset_harvester/multiview_diffusion/training/merge_lora.py
+++ b/asset_harvester/multiview_diffusion/training/merge_lora.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Merge a LoRA adapter from post-training into the base transformer weights.
+
+Produces a plain diffusers-format transformer directory (config.json +
+safetensors, no adapter modules) that the unchanged inference pipeline loads
+directly:
+
+    mvdiff-merge-lora \\
+        --base_checkpoint checkpoints/AH_multiview_diffusion.safetensors \\
+        --lora_dir outputs/post_training/transformer_lora \\
+        --output_dir outputs/post_training/transformer_merged
+
+    python run_inference.py --diffusion_checkpoint outputs/post_training/transformer_merged ...
+
+The merged weight of every adapted module is ``W + lora_scale * (alpha / r) * B @ A``.
+"""
+
+import argparse
+import os
+
+import torch
+
+from ..utils.model_builder import load_transformer_checkpoint
+
+LORA_WEIGHT_NAME = "pytorch_lora_weights.safetensors"
+
+
+def merge_lora(
+    base_checkpoint: str,
+    lora_dir: str,
+    output_dir: str,
+    lora_scale: float = 1.0,
+) -> int:
+    """Merge the adapter at ``lora_dir`` into ``base_checkpoint``; returns the
+    number of weight tensors the merge changed."""
+    if not os.path.isfile(os.path.join(lora_dir, LORA_WEIGHT_NAME)):
+        raise FileNotFoundError(f"No {LORA_WEIGHT_NAME} in {lora_dir}")
+
+    print(f"Loading base transformer from {base_checkpoint}")
+    transformer = load_transformer_checkpoint(base_checkpoint)
+    base_state = {k: v.detach().clone() for k, v in transformer.state_dict().items()}
+
+    print(f"Merging LoRA from {lora_dir} (scale={lora_scale})")
+    # prefix=None: adapters saved by save_lora_adapter carry unprefixed keys;
+    # the default prefix="transformer" silently matches nothing.
+    transformer.load_lora_adapter(lora_dir, weight_name=LORA_WEIGHT_NAME, prefix=None)
+    transformer.fuse_lora(lora_scale=lora_scale)
+    transformer.unload_lora()
+
+    merged_state = transformer.state_dict()
+    leftover = [k for k in merged_state if "lora" in k.lower()]
+    if leftover:
+        raise RuntimeError(f"Adapter modules were not fully unloaded: {leftover[:5]}")
+    if set(merged_state) != set(base_state):
+        raise RuntimeError("Merged state dict keys differ from the base model's")
+
+    changed = sum(1 for k in base_state if not torch.equal(base_state[k], merged_state[k]))
+    if changed == 0:
+        raise RuntimeError(
+            "Merge changed no weights — the adapter does not match this base model (or was saved untrained)"
+        )
+    print(f"Merge changed {changed}/{len(base_state)} weight tensors")
+
+    transformer.save_pretrained(output_dir)
+    print(f"Merged transformer saved to {output_dir}")
+    return changed
+
+
+def parse_args(input_args=None):
+    parser = argparse.ArgumentParser(description="Merge a LoRA adapter into SparseViewDiT base weights")
+    parser.add_argument(
+        "--base_checkpoint",
+        type=str,
+        required=True,
+        help="Base weights: released .safetensors file or a diffusers-format directory",
+    )
+    parser.add_argument(
+        "--lora_dir",
+        type=str,
+        required=True,
+        help=f"Directory containing {LORA_WEIGHT_NAME} (e.g. <run>/transformer_lora)",
+    )
+    parser.add_argument("--output_dir", type=str, required=True, help="Where to save the merged transformer")
+    parser.add_argument("--lora_scale", type=float, default=1.0, help="Strength multiplier for the adapter delta")
+    return parser.parse_args(input_args)
+
+
+def main(args=None):
+    if args is None:
+        args = parse_args()
+    merge_lora(args.base_checkpoint, args.lora_dir, args.output_dir, args.lora_scale)
+
+
+if __name__ == "__main__":
+    main()

--- a/asset_harvester/multiview_diffusion/training/train.py
+++ b/asset_harvester/multiview_diffusion/training/train.py
@@ -1,0 +1,581 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Rectified-flow post-training for the SparseViewDiT multiview diffusion model.
+
+Fine-tunes the released checkpoint (or a previously fine-tuned diffusers-format
+checkpoint) on ncore-parser sample directories with the same objective the
+model was pretrained with: logit-normal timestep sampling, linear-flow noising,
+and a velocity MSE on target views.
+
+Launch (single GPU):
+
+    accelerate launch -m asset_harvester.multiview_diffusion.training.train \\
+        --data_root /path/to/parsed_samples \\
+        --checkpoint_path checkpoints/AH_multiview_diffusion.safetensors \\
+        --output_dir outputs/post_training
+
+Multi-GPU: ``accelerate launch --multi_gpu --num_processes 8 -m ...``.
+"""
+
+import argparse
+import logging
+import math
+import os
+import shutil
+
+import torch
+import yaml
+from accelerate import Accelerator
+from accelerate.logging import get_logger
+from accelerate.utils import ProjectConfiguration, set_seed
+from diffusers import AutoencoderDC
+from diffusers.optimization import get_scheduler
+from diffusers.schedulers import DPMSolverMultistepScheduler
+from diffusers.training_utils import EMAModel
+from diffusers.utils.torch_utils import is_compiled_module
+from safetensors.torch import load_file
+
+from ..configs import load_unified_config
+from ..models.sparseviewdit import SparseViewDiTTransformer2DModelNative
+from ..pipelines import SparseViewDiTPipeline
+from ..utils.convert_checkpoint import convert_sana_ms_to_diffusers
+from ..utils.model_builder import get_c_radio
+from .cond_processor import MultiviewCondProcessor, make_validation_grid
+from .dataset import MultiviewObjectDataset, build_dataloader
+from .flow_match import RectifiedFlowSchedule, broadcast_to_views, flow_matching_loss, velocity_target
+
+logger = get_logger(__name__)
+
+
+def parse_args(input_args=None):
+    """Parse CLI args with defaults from the unified YAML config.
+
+    Precedence (lowest to highest): packaged sparseviewdit_512.yaml ->
+    ``--config`` file (may override a subset of training keys) -> CLI flags.
+    Run-specific paths (--data_root, --output_dir, ...) are CLI-only.
+    """
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Unified YAML config (model + training defaults). Defaults to the packaged sparseviewdit_512.yaml",
+    )
+    pre_args, _ = pre.parse_known_args(input_args)
+
+    base_config = load_unified_config()
+    model_config = base_config["model"]
+    training_defaults = dict(base_config["training"])
+    if pre_args.config is not None:
+        user_config = load_unified_config(pre_args.config)
+        model_config = user_config["model"]
+        training_defaults.update(user_config["training"])
+
+    parser = argparse.ArgumentParser(description="Rectified-flow post-training for SparseViewDiT", parents=[pre])
+
+    # Run-specific paths (CLI-only, never in the YAML config)
+    parser.add_argument("--data_root", type=str, required=True, help="Root dir of ncore-parser samples")
+    parser.add_argument("--val_data_root", type=str, default=None, help="Validation samples (default: data_root)")
+    parser.add_argument(
+        "--checkpoint_path",
+        type=str,
+        default=None,
+        help="Released single-file checkpoint (AH_multiview_diffusion.safetensors)",
+    )
+    parser.add_argument(
+        "--pretrained_model_path",
+        type=str,
+        default=None,
+        help="Diffusers-format transformer directory (e.g. a previous fine-tune output)",
+    )
+    parser.add_argument("--output_dir", type=str, default="outputs/post_training")
+    parser.add_argument("--resume_from_checkpoint", type=str, default=None, help='Path or "latest"')
+
+    # Everything below defaults from the unified config's `training` section.
+    # Data / preprocessing
+    parser.add_argument("--resolution", type=int)
+    parser.add_argument("--max_views", type=int)
+    parser.add_argument("--conditioning_min_n", type=int, help="0 supplies unconditional samples for CFG")
+    parser.add_argument("--conditioning_max_n", type=int)
+    parser.add_argument("--symmetry_aug_p", type=float)
+    parser.add_argument("--dataset_repeats", type=int, help="Virtual epoch multiplier for small datasets")
+    parser.add_argument("--dataloader_num_workers", type=int)
+
+    # Model options
+    parser.add_argument("--gradient_checkpointing", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--lora_rank", type=int, help="LoRA rank; 0 trains all parameters")
+    parser.add_argument("--lora_alpha", type=int, help="Defaults to lora_rank")
+
+    # Flow matching
+    parser.add_argument("--num_train_timesteps", type=int)
+    parser.add_argument("--flow_shift", type=float, help="1.0 at 512px; 3-4 at 1024px")
+    parser.add_argument("--weighting_scheme", type=str, choices=["logit_normal", "uniform"])
+    parser.add_argument("--logit_mean", type=float)
+    parser.add_argument("--logit_std", type=float)
+    parser.add_argument("--cfg_dropout_prob", type=float)
+
+    # Optimization
+    parser.add_argument("--train_batch_size", type=int, help="Objects (not views) per device")
+    parser.add_argument("--max_train_steps", type=int)
+    parser.add_argument("--gradient_accumulation_steps", type=int)
+    parser.add_argument("--learning_rate", type=float)
+    parser.add_argument("--lr_scheduler", type=str)
+    parser.add_argument("--lr_warmup_steps", type=int)
+    parser.add_argument("--adam_beta1", type=float)
+    parser.add_argument("--adam_beta2", type=float)
+    parser.add_argument("--adam_weight_decay", type=float)
+    parser.add_argument("--adam_epsilon", type=float)
+    parser.add_argument("--use_8bit_adam", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--max_grad_norm", type=float)
+    parser.add_argument("--mixed_precision", type=str, choices=["no", "fp16", "bf16"])
+    parser.add_argument("--use_ema", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--ema_decay", type=float)
+
+    # Checkpointing / logging / validation
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--checkpointing_steps", type=int)
+    parser.add_argument("--checkpoints_total_limit", type=int)
+    parser.add_argument("--validation_steps", type=int)
+    parser.add_argument("--num_validation_samples", type=int)
+    parser.add_argument("--validation_inference_steps", type=int)
+    parser.add_argument("--validation_guidance_scale", type=float)
+    parser.add_argument("--report_to", type=str, choices=["tensorboard", "wandb", "all"])
+    parser.add_argument("--tracker_project_name", type=str)
+    parser.add_argument("--log_interval", type=int)
+
+    known_dests = {action.dest for action in parser._actions}
+    unknown_keys = set(training_defaults) - known_dests
+    if unknown_keys:
+        parser.error(f"Unknown keys in the config's training section: {sorted(unknown_keys)}")
+    parser.set_defaults(**training_defaults)
+
+    args = parser.parse_args(input_args)
+
+    if (args.checkpoint_path is None) == (args.pretrained_model_path is None):
+        parser.error("Provide exactly one of --checkpoint_path or --pretrained_model_path")
+    if args.use_ema and args.lora_rank > 0:
+        parser.error("--use_ema is not supported together with LoRA (--lora_rank > 0)")
+    if args.lora_alpha is None:
+        args.lora_alpha = args.lora_rank
+    args.model_config = model_config
+    return args
+
+
+def load_transformer(args) -> SparseViewDiTTransformer2DModelNative:
+    """Load initial weights from the release single-file format or a diffusers dir."""
+    if args.pretrained_model_path is not None:
+        logger.info(f"Loading diffusers-format transformer from {args.pretrained_model_path}")
+        return SparseViewDiTTransformer2DModelNative.from_pretrained(args.pretrained_model_path)
+
+    logger.info(f"Loading release checkpoint from {args.checkpoint_path}")
+    transformer = SparseViewDiTTransformer2DModelNative(**args.model_config)
+    state_dict = load_file(args.checkpoint_path, device="cpu")
+    hidden_size = args.model_config["num_attention_heads"] * args.model_config["attention_head_dim"]
+    state_dict = convert_sana_ms_to_diffusers(state_dict, hidden_size=hidden_size)
+    missing, unexpected = transformer.load_state_dict(state_dict, strict=False)
+    logger.info(f"Checkpoint loaded (missing: {len(missing)}, unexpected: {len(unexpected)})")
+    return transformer
+
+
+def add_lora_adapter(transformer, rank: int, alpha: int):
+    from peft import LoraConfig
+
+    transformer.requires_grad_(False)
+    lora_config = LoraConfig(
+        r=rank,
+        lora_alpha=alpha,
+        init_lora_weights="gaussian",
+        target_modules=["to_q", "to_k", "to_v", "to_out.0"],
+    )
+    transformer.add_adapter(lora_config)
+
+
+@torch.no_grad()
+def log_validation(args, accelerator, transformer, vae, image_encoder, image_processor, val_dataset, global_step):
+    """Generate target views for validation objects and log grids of
+    [generated | ground truth | conditioning] rows to the trackers."""
+    logger.info(f"Running validation at step {global_step}")
+    transformer = accelerator.unwrap_model(transformer)
+    was_training = transformer.training
+    transformer.eval()
+
+    scheduler = DPMSolverMultistepScheduler(
+        num_train_timesteps=args.num_train_timesteps,
+        beta_schedule="scaled_linear",
+        prediction_type="flow_prediction",
+        flow_shift=args.flow_shift,
+        use_flow_sigmas=True,
+    )
+    pipeline = SparseViewDiTPipeline(
+        vae=vae,
+        transformer=transformer,
+        scheduler=scheduler,
+        image_encoder=image_encoder,
+        image_processor=image_processor,
+    )
+    pipeline.set_progress_bar_config(disable=True)
+
+    grids = []
+    for i in range(min(args.num_validation_samples, len(val_dataset))):
+        data_dict = val_dataset[i]
+        output = pipeline(
+            data_dict=data_dict,
+            num_inference_steps=args.validation_inference_steps,
+            guidance_scale=args.validation_guidance_scale,
+            flow_shift=args.flow_shift,
+            output_type="pil",
+        )
+        generated = output["images"]
+
+        def to_pil(t):
+            from PIL import Image
+
+            arr = ((t + 1.0) / 2.0 * 255).clamp(0, 255).permute(1, 2, 0).to(torch.uint8).cpu().numpy()
+            return Image.fromarray(arr)
+
+        n_target = data_dict.n_target
+        gt = [to_pil(data_dict.x[j]) for j in range(n_target)]
+        cond = [to_pil(data_dict.x[j]) for j in range(n_target, data_dict.x.shape[0])]
+        row_len = max(len(generated), 1)
+        grids.append(make_validation_grid(generated + gt + cond, views_per_row=row_len))
+
+    for tracker in accelerator.trackers:
+        if tracker.name == "tensorboard":
+            for i, grid in enumerate(grids):
+                tracker.writer.add_image(f"validation/sample_{i}", grid, global_step, dataformats="HWC")
+        elif tracker.name == "wandb":
+            import wandb
+
+            tracker.log(
+                {"validation": [wandb.Image(g, caption=f"sample {i}") for i, g in enumerate(grids)]},
+                step=global_step,
+            )
+
+    vis_dir = os.path.join(args.output_dir, "validation")
+    os.makedirs(vis_dir, exist_ok=True)
+    from PIL import Image
+
+    for i, grid in enumerate(grids):
+        Image.fromarray(grid).save(os.path.join(vis_dir, f"step{global_step:07d}_sample{i}.jpg"), quality=92)
+
+    if was_training:
+        transformer.train()
+    del pipeline
+    torch.cuda.empty_cache()
+
+
+def main(args=None):
+    if args is None:
+        args = parse_args()
+
+    logging_dir = os.path.join(args.output_dir, "logs")
+    project_config = ProjectConfiguration(project_dir=args.output_dir, logging_dir=logging_dir)
+    accelerator = Accelerator(
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        mixed_precision=args.mixed_precision,
+        log_with=args.report_to,
+        project_config=project_config,
+    )
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        level=logging.INFO,
+    )
+    logger.info(accelerator.state, main_process_only=False)
+    set_seed(args.seed, device_specific=True)
+    if accelerator.is_main_process:
+        os.makedirs(args.output_dir, exist_ok=True)
+        # Persist the fully resolved configuration (packaged defaults + --config
+        # overrides + CLI flags) next to the checkpoints for reproducibility.
+        resolved = {
+            "model": dict(args.model_config),
+            "training": {k: v for k, v in vars(args).items() if k not in ("model_config", "config")},
+        }
+        with open(os.path.join(args.output_dir, "training_config.yaml"), "w") as f:
+            yaml.safe_dump(resolved, f, sort_keys=True)
+
+    device = accelerator.device
+    weight_dtype = torch.float32  # params stay fp32; autocast handles bf16/fp16 compute
+
+    # ---------------- Models ----------------
+    # VAE always in fp32 (Sana requirement); frozen.
+    vae = AutoencoderDC.from_pretrained("mit-han-lab/dc-ae-f32c32-sana-1.0-diffusers")
+    vae.requires_grad_(False)
+    vae.to(device, dtype=torch.float32).eval()
+
+    image_encoder, image_processor = get_c_radio(device=device)
+    image_encoder.requires_grad_(False)
+
+    transformer = load_transformer(args)
+    if args.lora_rank > 0:
+        add_lora_adapter(transformer, args.lora_rank, args.lora_alpha)
+    else:
+        transformer.requires_grad_(True)
+    transformer.to(device, dtype=weight_dtype)
+    if args.gradient_checkpointing:
+        transformer.enable_gradient_checkpointing()
+
+    ema_model = None
+    if args.use_ema:
+        ema_model = EMAModel(
+            transformer.parameters(),
+            decay=args.ema_decay,
+            model_cls=SparseViewDiTTransformer2DModelNative,
+            model_config=transformer.config,
+        )
+        ema_model.to(device)
+
+    def unwrap_model(model):
+        model = accelerator.unwrap_model(model)
+        return model._orig_mod if is_compiled_module(model) else model
+
+    # ---------------- Checkpoint hooks ----------------
+    def save_model_hook(models, weights, output_dir):
+        if accelerator.is_main_process:
+            if ema_model is not None:
+                ema_model.save_pretrained(os.path.join(output_dir, "transformer_ema"))
+            for model in models:
+                m = unwrap_model(model)
+                if args.lora_rank > 0:
+                    m.save_lora_adapter(os.path.join(output_dir, "transformer_lora"))
+                else:
+                    m.save_pretrained(os.path.join(output_dir, "transformer"))
+                if weights:
+                    weights.pop()
+
+    def load_model_hook(models, input_dir):
+        if ema_model is not None:
+            loaded = EMAModel.from_pretrained(
+                os.path.join(input_dir, "transformer_ema"), model_cls=SparseViewDiTTransformer2DModelNative
+            )
+            ema_model.load_state_dict(loaded.state_dict())
+            ema_model.to(device)
+            del loaded
+        for _ in range(len(models)):
+            model = models.pop()
+            m = unwrap_model(model)
+            if args.lora_rank > 0:
+                # Copy the checkpointed adapter into the existing LoRA parameters
+                # in place (keys in the file are adapter-name-stripped:
+                # "X.lora_A.weight" vs parameter "X.lora_A.default.weight").
+                # In-place copy keeps the optimizer's parameter references valid.
+                adapter_state = load_file(
+                    os.path.join(input_dir, "transformer_lora", "pytorch_lora_weights.safetensors")
+                )
+                named_params = dict(m.named_parameters())
+                for key, value in adapter_state.items():
+                    param_key = key.replace(".lora_A.weight", ".lora_A.default.weight").replace(
+                        ".lora_B.weight", ".lora_B.default.weight"
+                    )
+                    named_params[param_key].data.copy_(value)
+            else:
+                loaded = SparseViewDiTTransformer2DModelNative.from_pretrained(input_dir, subfolder="transformer")
+                m.register_to_config(**loaded.config)
+                m.load_state_dict(loaded.state_dict())
+                del loaded
+
+    accelerator.register_save_state_pre_hook(save_model_hook)
+    accelerator.register_load_state_pre_hook(load_model_hook)
+
+    # ---------------- Data ----------------
+    train_dataset = MultiviewObjectDataset(
+        data_root=args.data_root,
+        resolution=args.resolution,
+        max_views=args.max_views,
+        conditioning_min_n=args.conditioning_min_n,
+        conditioning_max_n=args.conditioning_max_n,
+        symmetry_aug_p=args.symmetry_aug_p,
+        repeats=args.dataset_repeats,
+    )
+    train_dataloader = build_dataloader(
+        train_dataset,
+        batch_size=args.train_batch_size,
+        num_workers=args.dataloader_num_workers,
+        shuffle=True,
+        seed=args.seed,
+    )
+    # Validation: deterministic conditioning (max available views), no augmentation.
+    val_dataset = MultiviewObjectDataset(
+        data_root=args.val_data_root or args.data_root,
+        resolution=args.resolution,
+        max_views=args.max_views,
+        conditioning_mode="n",
+        conditioning_min_n=1,
+        conditioning_max_n=args.conditioning_max_n,
+        symmetry_aug_p=0.0,
+    )
+
+    processor = MultiviewCondProcessor(
+        vae, image_encoder, image_processor, weight_dtype=weight_dtype, cfg_dropout_prob=args.cfg_dropout_prob
+    )
+    schedule = RectifiedFlowSchedule(num_train_timesteps=args.num_train_timesteps, flow_shift=args.flow_shift)
+
+    # ---------------- Optimizer ----------------
+    params = [p for p in transformer.parameters() if p.requires_grad]
+    if args.use_8bit_adam:
+        import bitsandbytes as bnb
+
+        optimizer_cls = bnb.optim.AdamW8bit
+    else:
+        optimizer_cls = torch.optim.AdamW
+    optimizer = optimizer_cls(
+        params,
+        lr=args.learning_rate,
+        betas=(args.adam_beta1, args.adam_beta2),
+        weight_decay=args.adam_weight_decay,
+        eps=args.adam_epsilon,
+    )
+    lr_scheduler = get_scheduler(
+        args.lr_scheduler,
+        optimizer=optimizer,
+        num_warmup_steps=args.lr_warmup_steps * accelerator.num_processes,
+        num_training_steps=args.max_train_steps * accelerator.num_processes,
+    )
+
+    transformer, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+        transformer, optimizer, train_dataloader, lr_scheduler
+    )
+
+    if accelerator.is_main_process:
+        tracker_config = {k: v for k, v in vars(args).items() if isinstance(v, (bool, int, float, str)) or v is None}
+        accelerator.init_trackers(args.tracker_project_name, config=tracker_config)
+
+    total_batch_size = args.train_batch_size * accelerator.num_processes * args.gradient_accumulation_steps
+    logger.info("***** Running post-training *****")
+    logger.info(f"  Num samples = {len(train_dataset)} ({len(train_dataset.sample_dirs)} unique)")
+    logger.info(f"  Total objects/optimizer-step = {total_batch_size}")
+    logger.info(f"  Max optimizer steps = {args.max_train_steps}")
+    logger.info(f"  Trainable params = {sum(p.numel() for p in params) / 1e6:.1f}M")
+
+    # ---------------- Resume ----------------
+    global_step = 0
+    if args.resume_from_checkpoint:
+        if args.resume_from_checkpoint == "latest":
+            dirs = [d for d in os.listdir(args.output_dir) if d.startswith("checkpoint-")]
+            path = os.path.join(args.output_dir, sorted(dirs, key=lambda d: int(d.split("-")[1]))[-1]) if dirs else None
+        else:
+            path = args.resume_from_checkpoint
+        if path is None or not os.path.isdir(path):
+            logger.info("No checkpoint found; starting fresh")
+        else:
+            logger.info(f"Resuming from {path}")
+            accelerator.load_state(path)
+            global_step = int(os.path.basename(os.path.normpath(path)).split("-")[1])
+
+    # ---------------- Training loop ----------------
+    transformer.train()
+    num_update_steps_per_epoch = math.ceil(len(train_dataloader) / args.gradient_accumulation_steps)
+    first_epoch = global_step // max(num_update_steps_per_epoch, 1)
+    done = False
+
+    for epoch in range(first_epoch, 10**9):
+        if done:
+            break
+        for batch in train_dataloader:
+            with accelerator.accumulate(transformer):
+                inputs = processor(batch, device)
+
+                num_objects = len(inputs["views_per_object"])
+                t_obj = schedule.sample_timestep_indices(
+                    num_objects, args.weighting_scheme, args.logit_mean, args.logit_std
+                )
+                t_views = broadcast_to_views(t_obj, inputs["views_per_object"])
+
+                x0 = inputs["clean_latents"]
+                noise = torch.randn_like(x0)
+                x_t, model_ts = schedule.add_noise(x0, noise, t_views)
+
+                model_out = transformer(
+                    hidden_states=x_t,
+                    encoder_hidden_states=inputs["prompt_embeds"],
+                    timestep=model_ts.to(device),
+                    camera_emb=inputs["camera_emb"],
+                    relative_brightness=inputs["relative_brightness"],
+                    rays=inputs["rays"],
+                    cond_mask=inputs["cond_mask"],
+                    clean_images=x0 * inputs["cond_mask"],
+                    x_seq_len=inputs["views_per_object"],
+                    return_dict=False,
+                )[0]
+
+                target = velocity_target(x0, noise)
+                loss = flow_matching_loss(model_out, target, cond_mask=inputs["cond_mask"])
+
+                accelerator.backward(loss)
+                grad_norm = None
+                if accelerator.sync_gradients:
+                    grad_norm = accelerator.clip_grad_norm_(params, args.max_grad_norm)
+                optimizer.step()
+                lr_scheduler.step()
+                optimizer.zero_grad(set_to_none=True)
+
+            if accelerator.sync_gradients:
+                global_step += 1
+                if ema_model is not None:
+                    ema_model.step(transformer.parameters())
+
+                if global_step % args.log_interval == 0:
+                    logs = {"loss": loss.detach().item(), "lr": lr_scheduler.get_last_lr()[0]}
+                    if grad_norm is not None:
+                        logs["grad_norm"] = grad_norm.item() if torch.is_tensor(grad_norm) else float(grad_norm)
+                    accelerator.log(logs, step=global_step)
+                    logger.info(f"step {global_step}: " + ", ".join(f"{k}={v:.5g}" for k, v in logs.items()))
+
+                if global_step % args.checkpointing_steps == 0 and accelerator.is_main_process:
+                    if args.checkpoints_total_limit is not None:
+                        ckpts = sorted(
+                            (d for d in os.listdir(args.output_dir) if d.startswith("checkpoint-")),
+                            key=lambda d: int(d.split("-")[1]),
+                        )
+                        for d in ckpts[: max(0, len(ckpts) - args.checkpoints_total_limit + 1)]:
+                            logger.info(f"Removing old checkpoint {d}")
+                            shutil.rmtree(os.path.join(args.output_dir, d))
+                    save_path = os.path.join(args.output_dir, f"checkpoint-{global_step}")
+                    accelerator.save_state(save_path)
+                    logger.info(f"Saved checkpoint to {save_path}")
+
+                if global_step % args.validation_steps == 0 and accelerator.is_main_process:
+                    if ema_model is not None:
+                        ema_model.store(transformer.parameters())
+                        ema_model.copy_to(transformer.parameters())
+                    log_validation(
+                        args, accelerator, transformer, vae, image_encoder, image_processor, val_dataset, global_step
+                    )
+                    if ema_model is not None:
+                        ema_model.restore(transformer.parameters())
+
+                if global_step >= args.max_train_steps:
+                    done = True
+                    break
+
+    # ---------------- Final save ----------------
+    accelerator.wait_for_everyone()
+    if accelerator.is_main_process:
+        transformer = unwrap_model(transformer)
+        if ema_model is not None:
+            ema_model.copy_to(transformer.parameters())
+        if args.lora_rank > 0:
+            transformer.save_lora_adapter(os.path.join(args.output_dir, "transformer_lora"))
+        else:
+            transformer.save_pretrained(os.path.join(args.output_dir, "transformer"))
+        logger.info(f"Final model saved to {args.output_dir}")
+        log_validation(args, accelerator, transformer, vae, image_encoder, image_processor, val_dataset, global_step)
+    accelerator.end_training()
+
+
+if __name__ == "__main__":
+    main()

--- a/asset_harvester/multiview_diffusion/utils/model_builder.py
+++ b/asset_harvester/multiview_diffusion/utils/model_builder.py
@@ -29,6 +29,7 @@ from PIL import Image
 from safetensors.torch import load_file
 from transformers import AutoModel, CLIPImageProcessor
 
+from ..configs import load_unified_config
 from ..models.sparseviewdit import SparseViewDiTTransformer2DModelNative
 from .convert_checkpoint import convert_sana_ms_to_diffusers
 
@@ -122,25 +123,32 @@ def vae_decode(name, vae, latent):
     return samples
 
 
-_TRANSFORMER_CONFIG = dict(
-    in_channels=32,
-    out_channels=32,
-    num_attention_heads=70,  # 70 * 32 = 2240
-    attention_head_dim=32,
-    num_layers=20,
-    num_cross_attention_heads=20,
-    cross_attention_head_dim=112,  # 20 * 112 = 2240
-    cross_attention_dim=2240,
-    caption_channels=1280,
-    mlp_ratio=2.5,
-    patch_size=1,
-    sample_size=16,  # 16 * 32 = 512
-    camera_emb=True,
-    camera_emb_dim=17,
-    brightness_emb=True,
-    cond_on_rays=True,
-    cond_on_mask=True,
-)
+# Architecture of the released 512px checkpoint, from the unified config
+# (asset_harvester/multiview_diffusion/configs/sparseviewdit_512.yaml).
+_TRANSFORMER_CONFIG = load_unified_config()["model"]
+
+
+def load_transformer_checkpoint(checkpoint_path: str) -> SparseViewDiTTransformer2DModelNative:
+    """Load the transformer from either checkpoint format (fp32, on CPU).
+
+    Accepts the released single-file ``.safetensors`` (converted from the
+    original training layout) or a diffusers-format directory produced by
+    post-training's ``save_pretrained``.
+    """
+    import os
+
+    if os.path.isdir(checkpoint_path):
+        transformer = SparseViewDiTTransformer2DModelNative.from_pretrained(checkpoint_path)
+        print("   Diffusers-format checkpoint loaded")
+        return transformer
+
+    transformer = SparseViewDiTTransformer2DModelNative(**_TRANSFORMER_CONFIG)
+    state_dict = load_file(checkpoint_path, device="cpu")
+    hidden_size = _TRANSFORMER_CONFIG["num_attention_heads"] * _TRANSFORMER_CONFIG["attention_head_dim"]
+    state_dict = convert_sana_ms_to_diffusers(state_dict, hidden_size=hidden_size)
+    missing, unexpected = transformer.load_state_dict(state_dict, strict=False)
+    print(f"   Checkpoint converted and loaded (missing: {len(missing)}, unexpected: {len(unexpected)})")
+    return transformer
 
 
 def get_models(checkpoint_path, device, dtype):
@@ -157,11 +165,7 @@ def get_models(checkpoint_path, device, dtype):
 
     # 3. Load transformer
     print(f"\n Loading transformer from {checkpoint_path}...")
-    transformer = SparseViewDiTTransformer2DModelNative(**_TRANSFORMER_CONFIG)
-    state_dict = load_file(checkpoint_path, device="cpu")
-    state_dict = convert_sana_ms_to_diffusers(state_dict, hidden_size=2240)
-    missing, unexpected = transformer.load_state_dict(state_dict, strict=False)
-    print(f"   Checkpoint converted and loaded (missing: {len(missing)}, unexpected: {len(unexpected)})")
+    transformer = load_transformer_checkpoint(checkpoint_path)
 
     transformer = transformer.to(device).to(dtype)
     transformer.eval()

--- a/docs/post_training.md
+++ b/docs/post_training.md
@@ -1,0 +1,193 @@
+# Post-Training (Rectified-Flow Fine-Tuning)
+
+Asset Harvester supports post-training of the SparseViewDiT multiview diffusion model on
+your own data. Fine-tuning uses the same rectified-flow objective the released checkpoint
+was trained with, implemented on HuggingFace `diffusers` + `accelerate`:
+
+- **Noising**: `x_t = (1 - σ_t)·x0 + σ_t·ε` with a `linear_flow` sigma schedule and an
+  optional resolution-dependent timestep shift (`--flow_shift`, 1.0 at 512 px).
+- **Timestep sampling**: logit-normal (SD3-style), one timestep per object shared by all
+  of its views.
+- **Target**: velocity `v = ε - x0`, plain MSE on target views (conditioning views are
+  pasted back losslessly inside the model).
+- **CFG**: the C-RADIO image prompt is replaced by a null (grey-image) embedding with
+  probability `--cfg_dropout_prob`, and objects may draw 0 conditioning views
+  (`--conditioning_min_n 0`), preserving classifier-free guidance after fine-tuning.
+
+## Data
+
+Training consumes the same sample directories that `ncore-parser` produces and
+`run_inference.py` consumes: any folder tree whose leaves contain
+`input_views/camera.json` plus `frame_*` / `mask_*` images. Samples need **at least 2
+views** (≥1 conditioning + ≥1 target); single-view samples are skipped automatically.
+
+```
+my_dataset/
+  <sample_id>/
+    input_views/
+      camera.json
+      frame_00.jpeg  mask_00.png
+      frame_01.jpeg  mask_01.png
+      ...
+```
+
+At each step a random subset of views (between `--conditioning_min_n` and
+`--conditioning_max_n`) is used as conditioning and the rest become denoising targets,
+with the same preprocessing as inference (white-masked target backgrounds, Plucker rays,
+relative cameras, optional symmetry augmentation).
+
+### Dataset preparation
+
+For post-training on a new domain (fleet, sensor rig, object category), we recommend
+building a **mixed dataset** rather than fine-tuning on sparse real-world crops alone:
+
+- **Synthetic data (SDG)**: include multi-view object samples rendered or exported in
+  the `ncore-parser` layout above (posed images, masks, `camera.json`). In practice,
+  mixing general Objaverse-style objects with your own **vehicle SDG** helps stabilize
+  geometry, broaden viewpoint coverage, and reduce overfitting to the limited angles
+  typical of AV logs.
+- **Combining sources**: place all sample directories under one `--data_root`; training
+  randomly draws objects from the union. Tune the SDG vs. real/self-distilled ratio for
+  your domain.
+
+### Self-distillation from AV logs
+
+When your primary source is real driving data, a practical approach is to **expand and
+curate** sparse observations before fine-tuning:
+
+1. **NCore → cropped posed images** — parse clips with `ncore-parser` to obtain per-object
+   crops. See
+   [Step 1: NCore Parsing](end_to_end_example.md#step-1-ncore-parsing).
+2. **MVD generation** — run multiview diffusion (`run_inference.py` / `run.sh`) on those
+   crops to synthesize additional views around each object.
+3. **Filter and pick pairs** — combine the original sparse views with generated views in
+   per-object sample folders. Drop poor cases: heavy occlusion, broken masks, incoherent
+   generations. Optionally score retained objects with the
+   [benchmark](end_to_end_example.md#benchmark-evaluation) or manual review.
+
+
+## Setup
+
+Install the training extra on top of the standard setup:
+
+```bash
+pip install -e ".[multiview_diffusion,post_training]"
+```
+
+## Configuration
+
+The source of truth for both the model architecture and the training
+hyperparameters is the checked-in unified config
+[`asset_harvester/multiview_diffusion/configs/sparseviewdit_512.yaml`](../asset_harvester/multiview_diffusion/configs/sparseviewdit_512.yaml):
+
+- `model`: the released 512 px checkpoint's transformer architecture, shared by
+  inference (`model_builder`) and training. When training starts from a
+  diffusers-format directory (`--pretrained_model_path`), that directory's
+  `config.json` takes precedence.
+- `training`: default hyperparameters, loaded by `train.py` as argparse
+  defaults.
+
+Precedence (lowest to highest): packaged YAML → `--config /path/to/my.yaml`
+(a customized copy; only the keys you change need to differ) → CLI flags.
+Boolean options are negatable on the CLI (e.g. `--no-use_ema`) so a config
+`true` can be switched off per run. Run-specific paths (`--data_root`,
+`--output_dir`, `--checkpoint_path`, ...) are CLI-only by design.
+
+Every run writes the fully resolved configuration to
+`<output_dir>/training_config.yaml` for reproducibility.
+
+## Launch
+
+Single GPU:
+
+```bash
+accelerate launch --num_processes 1 --mixed_precision bf16 \
+    -m asset_harvester.multiview_diffusion.training.train \
+    --data_root /path/to/my_dataset \
+    --checkpoint_path checkpoints/AH_multiview_diffusion.safetensors \
+    --output_dir outputs/post_training \
+    --train_batch_size 1 \
+    --gradient_checkpointing \
+    --learning_rate 1e-5 \
+    --max_train_steps 10000
+```
+
+Multi-GPU (single node):
+
+```bash
+accelerate launch --multi_gpu --num_processes 8 --mixed_precision bf16 \
+    -m asset_harvester.multiview_diffusion.training.train ...
+```
+
+`scripts/run_post_training.sh` wraps the common case. The `mvdiff-train` console script
+is equivalent to `python -m asset_harvester.multiview_diffusion.training.train` (prefer
+`accelerate launch` so mixed precision and multi-GPU are handled for you).
+
+Useful options (see `--help` for all):
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `--config` | packaged YAML | Unified config supplying all defaults below |
+| `--checkpoint_path` | — | Released `.safetensors` file to start from |
+| `--pretrained_model_path` | — | Alternative: diffusers-format dir (e.g. a previous fine-tune) |
+| `--train_batch_size` | 1 | Objects (not views) per GPU; an object contributes up to `--max_views` views |
+| `--learning_rate` | 1e-5 | AdamW, constant schedule with warmup |
+| `--max_grad_norm` | 0.1 | Matches pretraining |
+| `--lora_rank` | 0 | > 0 trains a LoRA adapter (attention q/k/v/out) instead of all weights |
+| `--use_ema` | off | Maintain an EMA copy used for validation and the final save |
+| `--flow_shift` | 1.0 | Set 3–4 when fine-tuning at 1024 px |
+| `--cfg_dropout_prob` | 0.1 | Null-prompt probability (matches pretraining) |
+| `--resume_from_checkpoint` | — | Path or `latest` |
+| `--report_to` | tensorboard | `tensorboard`, `wandb`, or `all` |
+
+## Monitoring
+
+Loss, learning rate, and gradient norm are logged to the tracker; every
+`--validation_steps` the current model generates the target views of a few validation
+objects and logs `[generated | ground-truth | conditioning]` grids (also saved under
+`<output_dir>/validation/`).
+
+## Checkpoints and inference
+
+- Every `--checkpointing_steps` a full training state (`checkpoint-<step>/`) is saved for
+  resuming: transformer in diffusers format plus optimizer/scheduler/RNG state.
+- The final model is written to `<output_dir>/transformer/` (`config.json` +
+  safetensors). LoRA runs write `<output_dir>/transformer_lora/` instead.
+- Fine-tuned checkpoints plug directly into inference:
+
+```bash
+python run_inference.py \
+    --diffusion_checkpoint outputs/post_training/transformer \
+    --data_root /path/to/samples ...
+```
+
+### Using LoRA checkpoints at inference
+
+LoRA runs produce an adapter, not full weights. Merge it into the base model first
+(`W + lora_scale * (alpha / r) * B @ A`); the result is a plain diffusers-format
+transformer the unchanged inference pipeline loads:
+
+```bash
+mvdiff-merge-lora \
+    --base_checkpoint checkpoints/AH_multiview_diffusion.safetensors \
+    --lora_dir outputs/post_training/transformer_lora \
+    --output_dir outputs/post_training/transformer_merged
+
+python run_inference.py \
+    --diffusion_checkpoint outputs/post_training/transformer_merged \
+    --data_root /path/to/samples ...
+```
+
+`--base_checkpoint` accepts either checkpoint format and must be the same weights the
+adapter was trained on. `--lora_scale` (default 1.0) attenuates or amplifies the
+adapter's effect. Adapters saved inside training states
+(`checkpoint-<step>/transformer_lora`) merge the same way.
+
+## Tips
+
+- The released model was pretrained with the CAME optimizer at lr 1e-4; for fine-tuning,
+  AdamW at 1e-5–2e-5 with `--max_grad_norm 0.1` is a stable starting point.
+- For small datasets, raise `--dataset_repeats` so an "epoch" is long enough, and
+  consider `--lora_rank 16` to limit drift from the base model.
+- VRAM: full fine-tuning with one object per GPU fits
+  comfortably in 80 GB; gradient checkpointing may be needed for small GPUs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,13 +79,26 @@ camera-estimator = [
     "safetensors",
     "omegaconf>=2.3.0",
 ]
+# Rectified-flow post-training for the multiview diffusion model.
+# Requires the multiview_diffusion extra as well.
+post_training = [
+    "tensorboard",
+    "wandb==0.17.5",
+    "peft>=0.11.0",
+    "pytest>=7.0",
+]
 
 [project.scripts]
 ncore-parser = "asset_harvester.ncore_parser.__main__:main"
 tokengs-train = "asset_harvester.tokengs.main:main"
+mvdiff-train = "asset_harvester.multiview_diffusion.training.train:main"
+mvdiff-merge-lora = "asset_harvester.multiview_diffusion.training.merge_lora:main"
 
 [tool.setuptools.packages.find]
 include = ["asset_harvester*"]
+
+[tool.setuptools.package-data]
+"asset_harvester.multiview_diffusion.configs" = ["*.yaml"]
 
 [tool.ruff]
 line-length = 120

--- a/run.sh
+++ b/run.sh
@@ -30,7 +30,8 @@ Options:
   --data-root         Input directory with sample_paths.json
                       (default: outputs/ncore_parser/)
   --image-dir         Input directory with frame/mask pairs for direct inference
-  --diffusion-ckpt    Path to multiview diffusion .safetensors checkpoint
+  --diffusion-ckpt    Path to multiview diffusion checkpoint: released
+                      .safetensors file or diffusers-format transformer dir
                       (default: checkpoints/AH_multiview_diffusion.safetensors)
   --ahc-ckpt          Path to AHC .safetensors checkpoint
                       (default: checkpoints/AH_camera_estimator.safetensors)
@@ -96,7 +97,7 @@ done
 
 # --- Validate inputs ---
 
-if [ ! -f "${DIFFUSION_CKPT}" ]; then
+if [ ! -f "${DIFFUSION_CKPT}" ] && [ ! -d "${DIFFUSION_CKPT}" ]; then
     echo "ERROR: diffusion checkpoint not found at ${DIFFUSION_CKPT}"
     exit 1
 fi

--- a/run_inference.py
+++ b/run_inference.py
@@ -30,6 +30,11 @@ from PIL import Image
 from asset_harvester.camera_estimator.inference import AHCEstimator
 from asset_harvester.multiview_diffusion.data.inference_utils import build_eval_cams
 from asset_harvester.multiview_diffusion.data.nre_preproc import MVData, preproc
+from asset_harvester.multiview_diffusion.data.sample_loading import (
+    get_camera_file_paths,
+    load_camera_metadata,
+    load_multiview_sample,
+)
 from asset_harvester.multiview_diffusion.pipelines import SparseViewDiTPipeline
 from asset_harvester.multiview_diffusion.utils.model_builder import get_models
 from asset_harvester.utils.image_guard import DEFAULT_IMAGE_GUARD_THRESHOLD, ImageGuard
@@ -73,96 +78,6 @@ def load_sample_paths_from_json(data_root: str):
         return result
     except (json.JSONDecodeError, OSError):
         return None
-
-
-def load_camera_metadata(input_dir: str) -> dict:
-    """Load canonical camera metadata from input_views/camera.json."""
-    camera_path = os.path.join(input_dir, "camera.json")
-    if not os.path.isfile(camera_path):
-        raise FileNotFoundError(f"Missing camera.json in {input_dir}")
-
-    with open(camera_path) as f:
-        return json.load(f)
-
-
-def get_camera_file_paths(input_dir: str, cam_data: dict) -> tuple[list[str], list[str]]:
-    """Resolve ordered frame and mask file paths from camera metadata."""
-    frame_paths = [os.path.join(input_dir, filename) for filename in cam_data.get("frame_filenames", [])]
-    mask_paths = [os.path.join(input_dir, filename) for filename in cam_data.get("mask_filenames", [])]
-    return frame_paths, mask_paths
-
-
-def load_multiview_sample(sample_dir: str, allowed_indices: list[int] | None = None) -> MVData:
-    """
-    Load one sample from a ncore_parser (or compatible) output directory into an MVData instance
-    for use with inference preproc. Uses input_views only (frames, masks, camera.json).
-    """
-    input_dir = os.path.join(sample_dir, "input_views")
-    if not os.path.isdir(input_dir):
-        raise FileNotFoundError(f"Missing input_views: {input_dir}")
-
-    cam_data = load_camera_metadata(input_dir)
-    frame_filenames_all = cam_data["frame_filenames"]
-    frame_paths_all, mask_paths_all = get_camera_file_paths(input_dir, cam_data)
-    cam_poses_raw_all = cam_data["normalized_cam_positions"]
-    dists_list_all = cam_data["cam_dists"]
-    fov_list_all = cam_data["cam_fovs"]
-    lwh_list = cam_data["object_lwh"]
-
-    if allowed_indices is None:
-        allowed_indices = list(range(len(frame_filenames_all)))
-
-    frame_filenames = [frame_filenames_all[i] for i in allowed_indices]
-    frame_paths = [frame_paths_all[i] for i in allowed_indices]
-    mask_paths = [mask_paths_all[i] for i in allowed_indices]
-    cam_poses_raw = [cam_poses_raw_all[i] for i in allowed_indices]
-    dists_list = [dists_list_all[i] for i in allowed_indices]
-    fov_list = [fov_list_all[i] for i in allowed_indices]
-
-    n = len(frame_filenames)
-    if n == 0:
-        raise ValueError(f"No input views in {sample_dir}")
-
-    frames = []
-    masks = []
-    for path in frame_paths:
-        img = Image.open(path).convert("RGB")
-        frames.append(np.array(img))
-    for path in mask_paths:
-        mask_img = Image.open(path)
-        mask = np.array(mask_img)
-        if mask.ndim == 3:
-            mask = mask[:, :, 0]
-        masks.append(mask)
-
-    # cam_poses: (N, 3) camera positions
-    cam_poses = np.array(cam_poses_raw, dtype=np.float64).reshape(n, 3)
-
-    dists = np.array(dists_list, dtype=np.float64).reshape(n)
-    fov = np.array(fov_list, dtype=np.float64).reshape(n)
-    lwh = np.asarray(lwh_list, dtype=np.float64).reshape(3)
-
-    metadata_path = os.path.join(sample_dir, "metadata.json")
-    if os.path.isfile(metadata_path):
-        with open(metadata_path) as f:
-            meta = json.load(f)
-        clip_id = meta.get("clip_id", os.path.basename(sample_dir))
-    else:
-        clip_id = os.path.basename(sample_dir)
-    obj_id = os.path.basename(sample_dir)
-
-    return MVData(
-        clip_id=clip_id,
-        obj_id=obj_id,
-        frames=frames,
-        cam_poses=cam_poses,
-        dists=dists,
-        fov=fov,
-        npct="vehicle",
-        lwh=lwh,
-        masks=np.array(masks),
-        auto_label=None,
-    )
 
 
 def load_image_sample(image_pairs: list[tuple[str, str]], camera_estimator: AHCEstimator) -> MVData:
@@ -625,7 +540,7 @@ diffusers format at load time.
         "--diffusion_checkpoint",
         type=str,
         default=None,
-        help="Path to multiview diffusion model checkpoint (.safetensors file).",
+        help="Path to multiview diffusion checkpoint: released .safetensors file or a diffusers-format directory from post-training.",
     )
     parser.add_argument(
         "--ahc_checkpoint",

--- a/scripts/run_post_training.sh
+++ b/scripts/run_post_training.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Rectified-flow post-training of the SparseViewDiT multiview diffusion model.
+# Usage: bash scripts/run_post_training.sh <data_root> [output_dir] [num_gpus]
+# See docs/post_training.md for details and all options.
+
+set -euo pipefail
+
+DATA_ROOT="${1:?Usage: run_post_training.sh <data_root> [output_dir] [num_gpus]}"
+OUTPUT_DIR="${2:-outputs/post_training}"
+NUM_GPUS="${3:-1}"
+
+MULTI_GPU_FLAG=""
+if [[ "$NUM_GPUS" -gt 1 ]]; then
+    MULTI_GPU_FLAG="--multi_gpu"
+fi
+
+accelerate launch $MULTI_GPU_FLAG --num_processes "$NUM_GPUS" --mixed_precision bf16 \
+    -m asset_harvester.multiview_diffusion.training.train \
+    --data_root "$DATA_ROOT" \
+    --checkpoint_path checkpoints/AH_multiview_diffusion.safetensors \
+    --output_dir "$OUTPUT_DIR" \
+    --train_batch_size 1 \
+    --gradient_checkpointing \
+    --learning_rate 1e-5 \
+    --lr_warmup_steps 200 \
+    --max_train_steps 10000 \
+    --checkpointing_steps 500 \
+    --checkpoints_total_limit 3 \
+    --validation_steps 250 \
+    --resume_from_checkpoint latest \
+    --report_to tensorboard

--- a/tests/multiview_diffusion/test_dataset.py
+++ b/tests/multiview_diffusion/test_dataset.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for the training dataset over the bundled data_samples."""
+
+import os
+
+import pytest
+import torch
+
+from asset_harvester.multiview_diffusion.data.sample_loading import discover_sample_dirs
+from asset_harvester.multiview_diffusion.training.dataset import (
+    MultiviewObjectDataset,
+    build_dataloader,
+    collate_objects,
+)
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_DATA_ROOT = os.path.join(_REPO_ROOT, "data_samples", "rectified_AV_objects")
+
+pytestmark = pytest.mark.skipif(not os.path.isdir(_DATA_ROOT), reason="data_samples not present")
+
+
+def test_discover_sample_dirs():
+    dirs = discover_sample_dirs(_DATA_ROOT)
+    assert len(dirs) > 0
+    for d in dirs:
+        assert os.path.isfile(os.path.join(d, "input_views", "camera.json"))
+
+
+def test_dataset_item_shapes():
+    ds = MultiviewObjectDataset(data_root=_DATA_ROOT, resolution=512, conditioning_min_n=1)
+    obj = ds[0]
+
+    n_views = obj.x.shape[0]
+    assert 2 <= n_views <= 16
+    assert 1 <= obj.n_target < n_views
+
+    assert obj.x.shape == (n_views, 3, 512, 512)
+    assert obj.x_white_background.shape == (n_views, 3, 512, 512)
+    assert obj.plucker_image.shape[0] == n_views and obj.plucker_image.shape[1] == 6
+    assert obj.c2w_relatives.shape == (n_views, 4, 4)
+    assert obj.fovs.shape == (n_views,)
+    assert obj.relative_brightness.shape[0] == n_views
+    # Images are normalized to [-1, 1].
+    assert obj.x.min() >= -1.001 and obj.x.max() <= 1.001
+
+
+def test_dataset_repeats_and_collate():
+    ds = MultiviewObjectDataset(data_root=_DATA_ROOT, repeats=3, conditioning_min_n=1)
+    assert len(ds) == 3 * len(ds.sample_dirs)
+    batch = collate_objects([ds[0], ds[1]])
+    assert isinstance(batch, list) and len(batch) == 2
+
+
+def test_dataloader_yields_object_lists():
+    ds = MultiviewObjectDataset(data_root=_DATA_ROOT, repeats=2, conditioning_min_n=1)
+    dl = build_dataloader(ds, batch_size=2, num_workers=0, shuffle=True, seed=0)
+    batch = next(iter(dl))
+    assert isinstance(batch, list) and len(batch) == 2
+    assert all(torch.is_tensor(obj.x) for obj in batch)
+
+
+def test_single_view_samples_filtered():
+    # Any sample with fewer than 2 views cannot be used for training (needs
+    # >= 1 conditioning + >= 1 target) and must be dropped at init.
+    from asset_harvester.multiview_diffusion.training.dataset import _count_views
+
+    ds = MultiviewObjectDataset(data_root=_DATA_ROOT, conditioning_min_n=1)
+    assert all(_count_views(d) >= 2 for d in ds.sample_dirs)
+    # Every remaining item must load without retries exhausting.
+    for i in range(len(ds.sample_dirs)):
+        obj = ds[i]
+        assert obj.x.shape[0] >= 2
+
+
+def test_zero_conditioning_views_possible():
+    # With conditioning_min_n=0 some draws must produce fully unconditional objects.
+    ds = MultiviewObjectDataset(data_root=_DATA_ROOT, conditioning_min_n=0, repeats=1)
+    torch.manual_seed(0)
+    saw_zero_cond = False
+    for _ in range(30):
+        obj = ds[0]
+        if obj.x.shape[0] - obj.n_target == 0:
+            saw_zero_cond = True
+            break
+    assert saw_zero_cond

--- a/tests/multiview_diffusion/test_flow_match.py
+++ b/tests/multiview_diffusion/test_flow_match.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU unit tests for rectified-flow training utilities.
+
+The reference values encode the internal training implementation
+(linear_flow betas -> sigmas -> shift -> velocity MSE) so a regression here
+means a departure from the schedule the released checkpoint was trained with.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from asset_harvester.multiview_diffusion.training.flow_match import (
+    RectifiedFlowSchedule,
+    broadcast_to_views,
+    flow_matching_loss,
+    velocity_target,
+)
+
+
+class TestRectifiedFlowSchedule:
+    def test_sigma_endpoints_no_shift(self):
+        sched = RectifiedFlowSchedule(num_train_timesteps=1000, flow_shift=1.0)
+        assert sched.sigmas[0].item() == pytest.approx(0.0, abs=1e-12)
+        assert sched.sigmas[-1].item() == pytest.approx(0.999, abs=1e-12)
+        assert torch.all(sched.sigmas[1:] > sched.sigmas[:-1])
+
+    def test_matches_reference_linear_flow_schedule(self):
+        # Reference: betas = linspace(1.0, 0.001, N); sigmas = 1 - betas.
+        n = 1000
+        betas = np.linspace(1.0, 0.001, n, dtype=np.float64)
+        expected = 1.0 - betas
+        sched = RectifiedFlowSchedule(num_train_timesteps=n, flow_shift=1.0)
+        np.testing.assert_allclose(sched.sigmas.numpy(), expected, rtol=0, atol=1e-14)
+
+    def test_shift_formula(self):
+        n, shift = 1000, 3.0
+        base = RectifiedFlowSchedule(num_train_timesteps=n, flow_shift=1.0).sigmas.numpy()
+        shifted = RectifiedFlowSchedule(num_train_timesteps=n, flow_shift=shift).sigmas.numpy()
+        expected = shift * base / (1.0 + (shift - 1.0) * base)
+        np.testing.assert_allclose(shifted, expected, rtol=0, atol=1e-14)
+        # Shift preserves the endpoints and pushes interior sigmas toward noise.
+        assert shifted[0] == pytest.approx(0.0, abs=1e-12)
+        assert shifted[500] > base[500]
+
+    def test_model_timesteps_are_scaled_sigmas(self):
+        sched = RectifiedFlowSchedule(num_train_timesteps=1000, flow_shift=1.0)
+        np.testing.assert_allclose(sched.timesteps.numpy(), sched.sigmas.numpy() * 1000, atol=1e-12)
+
+    def test_logit_normal_sampling_range_and_center(self):
+        sched = RectifiedFlowSchedule()
+        gen = torch.Generator().manual_seed(0)
+        idx = sched.sample_timestep_indices(20000, "logit_normal", 0.0, 1.0, generator=gen)
+        assert idx.dtype == torch.long
+        assert idx.min() >= 0 and idx.max() <= 999
+        # sigmoid of a standard normal is symmetric around 0.5.
+        assert abs(idx.float().mean().item() - 500.0) < 10.0
+
+    def test_uniform_sampling(self):
+        sched = RectifiedFlowSchedule()
+        gen = torch.Generator().manual_seed(0)
+        idx = sched.sample_timestep_indices(10000, "uniform", generator=gen)
+        assert idx.min() >= 0 and idx.max() <= 999
+
+    def test_add_noise_interpolation(self):
+        sched = RectifiedFlowSchedule(num_train_timesteps=1000, flow_shift=1.0)
+        x0 = torch.randn(4, 32, 16, 16)
+        noise = torch.randn_like(x0)
+        # sigma[0] == 0 -> x_t == x0 exactly.
+        t0 = torch.zeros(4, dtype=torch.long)
+        x_t, ts = sched.add_noise(x0, noise, t0)
+        torch.testing.assert_close(x_t, x0)
+        torch.testing.assert_close(ts, torch.zeros(4))
+        # Interior index: exact linear interpolation.
+        t = torch.full((4,), 500, dtype=torch.long)
+        sigma = sched.sigmas[500].item()
+        x_t, ts = sched.add_noise(x0, noise, t)
+        torch.testing.assert_close(x_t, (1 - sigma) * x0 + sigma * noise)
+        assert ts[0].item() == pytest.approx(sigma * 1000, rel=1e-6)
+
+    def test_add_noise_rejects_unbroadcast_indices(self):
+        sched = RectifiedFlowSchedule()
+        x0 = torch.randn(6, 32, 16, 16)
+        with pytest.raises(ValueError, match="broadcast"):
+            sched.add_noise(x0, torch.randn_like(x0), torch.zeros(2, dtype=torch.long))
+
+
+def test_broadcast_to_views():
+    per_object = torch.tensor([10, 20, 30])
+    out = broadcast_to_views(per_object, [2, 1, 3])
+    torch.testing.assert_close(out, torch.tensor([10, 10, 20, 30, 30, 30]))
+    with pytest.raises(ValueError):
+        broadcast_to_views(per_object, [1, 2])
+
+
+def test_velocity_target():
+    x0 = torch.randn(3, 4)
+    noise = torch.randn(3, 4)
+    torch.testing.assert_close(velocity_target(x0, noise), noise - x0)
+
+
+class TestFlowMatchingLoss:
+    def test_unmasked_equals_mse(self):
+        pred = torch.randn(5, 32, 16, 16)
+        target = torch.randn_like(pred)
+        expected = torch.nn.functional.mse_loss(pred, target)
+        torch.testing.assert_close(flow_matching_loss(pred, target), expected)
+
+    def test_masked_gradients_match_reference_unmasked_loss(self):
+        # Reference behaviour: mean over ALL views of the per-view MSE, where the
+        # model output on conditioning views is a pasted-back constant (no grad).
+        # Our masked loss must produce identical gradients on the raw output.
+        torch.manual_seed(0)
+        n_views, n_target = 6, 4
+        raw = torch.randn(n_views, 32, 8, 8, requires_grad=True)
+        clean = torch.randn(n_views, 32, 8, 8)
+        target = torch.randn(n_views, 32, 8, 8)
+        cond_mask = torch.cat([torch.zeros(n_target, 32, 8, 8), torch.ones(n_views - n_target, 32, 8, 8)])
+
+        pasted = cond_mask * clean + (1 - cond_mask) * raw
+
+        # Reference: plain mean_flat over everything, including cond-view residual.
+        ref_loss = ((pasted - target) ** 2).mean(dim=(1, 2, 3)).mean()
+        (ref_grad,) = torch.autograd.grad(ref_loss, raw, retain_graph=True)
+
+        ours = flow_matching_loss(pasted, target, cond_mask=cond_mask)
+        (our_grad,) = torch.autograd.grad(ours, raw)
+
+        torch.testing.assert_close(our_grad, ref_grad)
+        # And the masked value excludes the conditioning-view residual.
+        target_only = ((pasted[:n_target] - target[:n_target]) ** 2).mean(dim=(1, 2, 3)).sum() / n_views
+        torch.testing.assert_close(ours, target_only)
+
+    def test_all_target_views_mask_is_noop(self):
+        pred = torch.randn(4, 8, 4, 4)
+        target = torch.randn_like(pred)
+        cond_mask = torch.zeros_like(pred)
+        torch.testing.assert_close(flow_matching_loss(pred, target, cond_mask), flow_matching_loss(pred, target))

--- a/tests/multiview_diffusion/test_merge_lora.py
+++ b/tests/multiview_diffusion/test_merge_lora.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU tests for merging LoRA adapters into base weights (merge_lora.py)."""
+
+import pytest
+import torch
+from peft import LoraConfig
+
+from asset_harvester.multiview_diffusion.models.sparseviewdit import SparseViewDiTTransformer2DModelNative
+from asset_harvester.multiview_diffusion.training.merge_lora import merge_lora
+
+_TINY_CONFIG = dict(
+    in_channels=8,
+    out_channels=8,
+    num_attention_heads=2,
+    attention_head_dim=8,
+    num_layers=1,
+    num_cross_attention_heads=2,
+    cross_attention_head_dim=8,
+    cross_attention_dim=16,
+    caption_channels=12,
+    mlp_ratio=1.0,
+    patch_size=1,
+    sample_size=4,
+    camera_emb=True,
+    camera_emb_dim=17,
+    brightness_emb=True,
+    cond_on_rays=True,
+    cond_on_mask=True,
+)
+
+_RANK, _ALPHA = 4, 8
+
+
+@pytest.fixture
+def base_and_adapter(tmp_path):
+    """A tiny base model saved to disk plus a nonzero LoRA adapter for it."""
+    torch.manual_seed(0)
+    model = SparseViewDiTTransformer2DModelNative(**_TINY_CONFIG)
+    base_dir = tmp_path / "base"
+    model.save_pretrained(base_dir)
+
+    model.add_adapter(
+        LoraConfig(
+            r=_RANK,
+            lora_alpha=_ALPHA,
+            init_lora_weights="gaussian",
+            target_modules=["to_q", "to_k", "to_v", "to_out.0"],
+        )
+    )
+    # lora_B is zero-initialized; randomize it so the merge is a real delta.
+    for name, param in model.named_parameters():
+        if "lora_B" in name:
+            torch.nn.init.normal_(param, std=0.1)
+    lora_dir = tmp_path / "lora"
+    model.save_lora_adapter(lora_dir)
+
+    lora_params = {n: p.detach().clone() for n, p in model.named_parameters() if "lora_" in n}
+    return base_dir, lora_dir, lora_params
+
+
+def test_merge_matches_manual_delta(base_and_adapter, tmp_path):
+    base_dir, lora_dir, lora_params = base_and_adapter
+    out_dir = tmp_path / "merged"
+    changed = merge_lora(str(base_dir), str(lora_dir), str(out_dir), lora_scale=1.0)
+    assert changed == len(lora_params) // 2  # one changed weight per (A, B) pair
+
+    base = SparseViewDiTTransformer2DModelNative.from_pretrained(base_dir)
+    merged = SparseViewDiTTransformer2DModelNative.from_pretrained(out_dir)
+
+    # No adapter keys survive, and every adapted module carries W + (alpha/r) B A.
+    assert all("lora" not in k for k in merged.state_dict())
+    module = "transformer_blocks.0.attn1.to_q"
+    a = lora_params[f"{module}.lora_A.default.weight"]
+    b = lora_params[f"{module}.lora_B.default.weight"]
+    expected = base.state_dict()[f"{module}.weight"] + (_ALPHA / _RANK) * (b @ a)
+    torch.testing.assert_close(merged.state_dict()[f"{module}.weight"], expected, atol=1e-6, rtol=0)
+    # Non-adapted weights are untouched.
+    torch.testing.assert_close(
+        merged.state_dict()["patch_embed.proj.weight"], base.state_dict()["patch_embed.proj.weight"]
+    )
+
+
+def test_merge_lora_scale(base_and_adapter, tmp_path):
+    base_dir, lora_dir, lora_params = base_and_adapter
+    merge_lora(str(base_dir), str(lora_dir), str(tmp_path / "half"), lora_scale=0.5)
+
+    base = SparseViewDiTTransformer2DModelNative.from_pretrained(base_dir)
+    half = SparseViewDiTTransformer2DModelNative.from_pretrained(tmp_path / "half")
+    module = "transformer_blocks.0.attn1.to_v"
+    a = lora_params[f"{module}.lora_A.default.weight"]
+    b = lora_params[f"{module}.lora_B.default.weight"]
+    expected = base.state_dict()[f"{module}.weight"] + 0.5 * (_ALPHA / _RANK) * (b @ a)
+    torch.testing.assert_close(half.state_dict()[f"{module}.weight"], expected, atol=1e-6, rtol=0)
+
+
+def test_merge_rejects_untrained_adapter(tmp_path):
+    # A freshly-initialized adapter (lora_B == 0) merges to a zero delta, which
+    # almost certainly means the wrong adapter was passed — must be an error.
+    torch.manual_seed(0)
+    model = SparseViewDiTTransformer2DModelNative(**_TINY_CONFIG)
+    base_dir = tmp_path / "base"
+    model.save_pretrained(base_dir)
+    model.add_adapter(LoraConfig(r=_RANK, lora_alpha=_ALPHA, target_modules=["to_q"]))
+    lora_dir = tmp_path / "lora"
+    model.save_lora_adapter(lora_dir)
+
+    with pytest.raises(RuntimeError, match="changed no weights"):
+        merge_lora(str(base_dir), str(lora_dir), str(tmp_path / "merged"))
+
+
+def test_merge_missing_adapter_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        merge_lora("unused", str(tmp_path), str(tmp_path / "out"))

--- a/tests/multiview_diffusion/test_model_serialization.py
+++ b/tests/multiview_diffusion/test_model_serialization.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""save_pretrained/from_pretrained round-trip for the multiview transformer.
+
+Regression test: the constructor widens in_channels for ray/mask conditioning
+before calling the base class, whose register_to_config used to persist the
+widened value — making every from_pretrained widen the input a second time
+(39 -> 46 channels) and fail to load the saved weights.
+"""
+
+import torch
+
+from asset_harvester.multiview_diffusion.models.sparseviewdit import SparseViewDiTTransformer2DModelNative
+
+_TINY_CONFIG = dict(
+    in_channels=8,
+    out_channels=8,
+    num_attention_heads=2,
+    attention_head_dim=8,
+    num_layers=1,
+    num_cross_attention_heads=2,
+    cross_attention_head_dim=8,
+    cross_attention_dim=16,
+    caption_channels=12,
+    mlp_ratio=1.0,
+    patch_size=1,
+    sample_size=4,
+    camera_emb=True,
+    camera_emb_dim=17,
+    brightness_emb=True,
+    cond_on_rays=True,
+    cond_on_mask=True,
+)
+
+
+def test_save_load_round_trip(tmp_path):
+    model = SparseViewDiTTransformer2DModelNative(**_TINY_CONFIG)
+    # Config must record the logical latent channels, not the widened width.
+    assert model.config.in_channels == 8
+    assert model.patch_embed.proj.weight.shape[1] == 8 + 6 + 1  # latents + rays + mask
+
+    model.save_pretrained(tmp_path)
+    reloaded = SparseViewDiTTransformer2DModelNative.from_pretrained(tmp_path)
+
+    assert reloaded.config.in_channels == 8
+    assert reloaded.patch_embed.proj.weight.shape == model.patch_embed.proj.weight.shape
+    torch.testing.assert_close(reloaded.patch_embed.proj.weight, model.patch_embed.proj.weight)
+    for (name_a, a), (_name_b, b) in zip(model.state_dict().items(), reloaded.state_dict().items(), strict=True):
+        torch.testing.assert_close(a, b, msg=f"mismatch in {name_a}")

--- a/tests/multiview_diffusion/test_training_gpu.py
+++ b/tests/multiview_diffusion/test_training_gpu.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU integration test: dataset -> conditioning -> noising -> forward -> loss -> backward.
+
+Requires a CUDA device and the released checkpoint; set AH_CHECKPOINT to the
+multiview diffusion safetensors file (default: <repo>/checkpoints/).
+"""
+
+import os
+
+import pytest
+import torch
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_DATA_ROOT = os.path.join(_REPO_ROOT, "data_samples", "rectified_AV_objects")
+_CHECKPOINT = os.environ.get(
+    "AH_CHECKPOINT", os.path.join(_REPO_ROOT, "checkpoints", "AH_multiview_diffusion.safetensors")
+)
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA"),
+    pytest.mark.skipif(not os.path.isfile(_CHECKPOINT), reason="checkpoint not found"),
+    pytest.mark.skipif(not os.path.isdir(_DATA_ROOT), reason="data_samples not present"),
+]
+
+
+@pytest.fixture(scope="module")
+def models():
+    from asset_harvester.multiview_diffusion.utils.model_builder import get_models
+
+    vae, cradio, cradio_proc, transformer = get_models(_CHECKPOINT, device="cuda", dtype=torch.bfloat16)
+    # Training setup: fp32 VAE, trainable transformer.
+    vae = vae.to(torch.float32)
+    transformer.train().requires_grad_(True)
+    return vae, cradio, cradio_proc, transformer
+
+
+def test_train_step_end_to_end(models):
+    from asset_harvester.multiview_diffusion.training.cond_processor import MultiviewCondProcessor
+    from asset_harvester.multiview_diffusion.training.dataset import MultiviewObjectDataset
+    from asset_harvester.multiview_diffusion.training.flow_match import (
+        RectifiedFlowSchedule,
+        broadcast_to_views,
+        flow_matching_loss,
+        velocity_target,
+    )
+
+    vae, cradio, cradio_proc, transformer = models
+    device = torch.device("cuda")
+
+    torch.manual_seed(0)
+    ds = MultiviewObjectDataset(data_root=_DATA_ROOT, conditioning_min_n=1)
+    objects = [ds[0], ds[1]]
+
+    processor = MultiviewCondProcessor(vae, cradio, cradio_proc, weight_dtype=torch.bfloat16)
+    batch = processor(objects, device)
+
+    total_views = sum(batch["views_per_object"])
+    assert batch["clean_latents"].shape == (total_views, 32, 16, 16)
+    assert batch["rays"].shape == (total_views, 6, 16, 16)
+    assert batch["cond_mask"].shape == (total_views, 32, 16, 16)
+    assert batch["camera_emb"].shape == (total_views, 17)
+    assert batch["prompt_embeds"].shape[0] == len(objects)
+
+    schedule = RectifiedFlowSchedule(num_train_timesteps=1000, flow_shift=1.0)
+    t_obj = schedule.sample_timestep_indices(len(objects), "logit_normal")
+    t_views = broadcast_to_views(t_obj, batch["views_per_object"])
+
+    x0 = batch["clean_latents"].float()
+    noise = torch.randn_like(x0)
+    x_t, model_ts = schedule.add_noise(x0, noise, t_views)
+
+    out = transformer(
+        hidden_states=x_t.to(torch.bfloat16),
+        encoder_hidden_states=batch["prompt_embeds"],
+        timestep=model_ts.to(device),
+        camera_emb=batch["camera_emb"],
+        relative_brightness=batch["relative_brightness"],
+        rays=batch["rays"],
+        cond_mask=batch["cond_mask"],
+        clean_images=batch["clean_latents"],
+        x_seq_len=batch["views_per_object"],
+        return_dict=False,
+    )[0]
+
+    target = velocity_target(x0, noise)
+    loss = flow_matching_loss(out, target, cond_mask=batch["cond_mask"])
+    assert torch.isfinite(loss), f"non-finite loss: {loss}"
+
+    loss.backward()
+    grads = [p.grad for p in transformer.parameters() if p.grad is not None]
+    assert len(grads) > 0
+    total_norm = torch.norm(torch.stack([g.detach().float().norm() for g in grads]))
+    assert torch.isfinite(total_norm)
+    transformer.zero_grad(set_to_none=True)
+
+    # A pretrained model should predict velocity far better than chance:
+    # the loss must be well below the variance of the target (~2 for v = eps - x0).
+    assert loss.item() < 1.5, f"pretrained model loss suspiciously high: {loss.item()}"
+
+
+def test_null_prompt_and_cfg_dropout(models):
+    from asset_harvester.multiview_diffusion.training.cond_processor import MultiviewCondProcessor
+    from asset_harvester.multiview_diffusion.training.dataset import MultiviewObjectDataset
+
+    vae, cradio, cradio_proc, _ = models
+    device = torch.device("cuda")
+
+    processor = MultiviewCondProcessor(vae, cradio, cradio_proc, weight_dtype=torch.bfloat16, cfg_dropout_prob=1.0)
+    null = processor.null_image_prompt(device)
+    assert null.shape[0] == 1 and null.ndim == 3
+
+    ds = MultiviewObjectDataset(data_root=_DATA_ROOT, conditioning_min_n=1)
+    batch = processor([ds[0]], device)
+    # With dropout probability 1.0 the prompt must be the null embedding.
+    torch.testing.assert_close(batch["prompt_embeds"], null.to(batch["prompt_embeds"].dtype))

--- a/tests/multiview_diffusion/test_unified_config.py
+++ b/tests/multiview_diffusion/test_unified_config.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the unified model/training config (source of truth YAML)."""
+
+import inspect
+
+import pytest
+import yaml
+
+from asset_harvester.multiview_diffusion.configs import DEFAULT_CONFIG_PATH, load_unified_config
+from asset_harvester.multiview_diffusion.models.sparseviewdit import SparseViewDiTTransformer2DModelNative
+from asset_harvester.multiview_diffusion.training.train import parse_args
+
+_MINIMAL_CLI = ["--data_root", "x", "--checkpoint_path", "y"]
+
+
+def test_default_config_loads_and_has_sections():
+    config = load_unified_config()
+    assert set(config) >= {"model", "training"}
+    assert config["model"]["num_attention_heads"] * config["model"]["attention_head_dim"] == 2240
+
+
+def test_model_section_matches_transformer_signature():
+    # Every model key must be an actual constructor parameter, so the YAML
+    # cannot drift from the model class.
+    config = load_unified_config()
+    params = set(inspect.signature(SparseViewDiTTransformer2DModelNative.__init__).parameters)
+    unknown = set(config["model"]) - params
+    assert not unknown, f"model config keys not accepted by the transformer: {unknown}"
+
+
+def test_model_builder_uses_unified_config():
+    from asset_harvester.multiview_diffusion.utils.model_builder import _TRANSFORMER_CONFIG
+
+    assert _TRANSFORMER_CONFIG == load_unified_config()["model"]
+
+
+def test_parse_args_defaults_come_from_yaml():
+    config = load_unified_config()
+    args = parse_args(_MINIMAL_CLI)
+    for key, expected in config["training"].items():
+        if key == "lora_alpha":  # resolved to lora_rank post-parse
+            expected = config["training"]["lora_rank"]
+        assert getattr(args, key) == expected, f"{key}: {getattr(args, key)} != {expected}"
+    assert args.model_config == config["model"]
+
+
+def test_cli_overrides_yaml_defaults():
+    args = parse_args(_MINIMAL_CLI + ["--learning_rate", "3e-4", "--use_ema", "--flow_shift", "3.0"])
+    assert args.learning_rate == pytest.approx(3e-4)
+    assert args.use_ema is True
+    assert args.flow_shift == pytest.approx(3.0)
+    # Boolean flags are negatable so a YAML `true` can be turned off on the CLI.
+    args = parse_args(_MINIMAL_CLI + ["--no-use_ema"])
+    assert args.use_ema is False
+
+
+def test_custom_config_file_overrides_defaults(tmp_path):
+    config = load_unified_config()
+    config["training"]["learning_rate"] = 7e-6
+    config["training"]["max_train_steps"] = 123
+    path = tmp_path / "custom.yaml"
+    path.write_text(yaml.safe_dump(config))
+
+    args = parse_args(["--config", str(path)] + _MINIMAL_CLI)
+    assert args.learning_rate == pytest.approx(7e-6)
+    assert args.max_train_steps == 123
+    # CLI still wins over the custom file.
+    args = parse_args(["--config", str(path)] + _MINIMAL_CLI + ["--max_train_steps", "5"])
+    assert args.max_train_steps == 5
+
+
+def test_unknown_training_key_rejected(tmp_path):
+    config = load_unified_config()
+    config["training"]["not_a_real_option"] = 1
+    path = tmp_path / "bad.yaml"
+    path.write_text(yaml.safe_dump(config))
+    with pytest.raises(SystemExit):
+        parse_args(["--config", str(path)] + _MINIMAL_CLI)
+
+
+def test_missing_section_rejected(tmp_path):
+    path = tmp_path / "no_model.yaml"
+    path.write_text(yaml.safe_dump({"training": {}}))
+    with pytest.raises(ValueError, match="model"):
+        load_unified_config(path)
+
+
+def test_default_path_is_packaged():
+    assert DEFAULT_CONFIG_PATH.name == "sparseviewdit_512.yaml"
+    assert DEFAULT_CONFIG_PATH.is_file()


### PR DESCRIPTION
Add a rectified-flow fine-tuning pipeline for the SparseViewDiT multiview diffusion model so users can adapt the released checkpoint to their own data:

- flow-matching training utilities, conditioning processor, and training dataset (samples with fewer than 2 views are filtered out)
- training loop with LoRA support and a unified model/training config checked in as the source of truth
- LoRA merging so fine-tuned adapters run through unchanged inference, plus diffusers-format transformer checkpoint loading in inference
- fix in_channels double-widening on save_pretrained round-trip
- post-training user guide with data preparation guidance, launch script, and README link
- tests covering dataset, flow matching, LoRA merge, serialization, unified config, and a GPU training smoke test