### PR TITLE
docs: add support issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a bug report to help us improve NuRec
+title: "[BUG]"
+labels: "? - Needs Triage, bug"
+assignees: 'daehyoungko'
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps/Code to reproduce bug**
+Follow this guide http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports to craft a minimal bug report. This helps us reproduce the issue and resolve it more quickly.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment overview (please complete the following information)**
+ - Asset Harvester workflow/component: [NCore parser, multiview diffusion, camera estimator, TokenGS lifting, NuRec asset preparation, benchmark, or post-training]
+ - Installation method: [`bash setup.sh` or manual editable install; include the command and selected extras]
+ - Asset Harvester version: [release version or Git commit]
+ - Model checkpoints used: [checkpoint filenames or Hugging Face revision]
+ - Input type: [NCore V4 clip/component store, posed multiview images, or single-view images and masks]
+
+**Environment details**
+ - GPU model(s), GPU count, and VRAM per GPU
+ - NVIDIA driver and CUDA toolkit versions
+ - Operating system, Python version, and Conda environment name
+ - GCC version
+ - PyTorch and relevant dependency versions (for example, `gsplat`, `diffusers`, and `transformers`)
+ - NCore version, if the issue involves NCore parsing
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# .github/ISSUE_TEMPLATE/config.yml — NuRec family
+# Place this file at .github/ISSUE_TEMPLATE/config.yml in the repo root.
+#
+# GitHub Issues is reserved for code-level bugs, documentation
+# requests, and feature requests. Usage questions route via the contact_link
+# below; security reporting is handled by the repo's SECURITY.md — GitHub adds
+# its own "Report a security vulnerability" link automatically, so we do NOT
+# ship one here (avoids a duplicate security entry in the chooser).
+
+blank_issues_enabled: false
+
+contact_links:
+  - name: 💬 Submit a question (usage, how-to)
+    url: https://forums.developer.nvidia.com/c/omniverse/platform/nurec/752
+    about: >
+      For usage questions and discussion, please post on the NVIDIA Developer Forum (Omniverse / NuRec category). The support team monitors this category and answers there.

--- a/.github/ISSUE_TEMPLATE/documentation_request_template.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request_template.md
@@ -1,0 +1,35 @@
+---
+name: Documentation request
+about: Report incorrect or needed documentation for NuRec
+title: "[DOC]"
+labels: "? - Needs Triage, doc"
+assignees: 'daehyoungko'
+
+---
+
+## Report incorrect documentation
+
+**Location of incorrect documentation**
+Provide the URL or repository path and the relevant heading or line numbers. For example: `docs/end_to_end_example.md`, Step 2.
+
+**Describe the problems or issues found in the documentation**
+Explain what is incorrect, outdated, or unclear, including the affected command, option, input format, checkpoint, or expected output.
+
+**Steps taken to verify documentation is incorrect**
+Describe what you tried and the result you observed. Include the command or workflow you used when applicable.
+
+**Suggested fix for documentation**
+Provide corrected wording, commands, links, or an example configuration if you have them.
+
+---
+
+## Report needed documentation
+
+**Report needed documentation**
+Describe the missing documentation and why it is needed. For example: NCore input preparation, image-to-3D inference, Gaussian-splat output, NuRec insertion, benchmarking, or post-training.
+
+**Describe the documentation you'd like**
+Describe the workflow, audience, and expected outcome the new documentation should cover. Include a representative input or command if helpful.
+
+**Steps taken to search for needed documentation**
+List where you searched, such as the README User Guide, `docs/end_to_end_example.md`, `docs/post_training.md`, or `benchmark/README.md`.

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for NuRec
+title: "[FEA]"
+labels: "? - Needs Triage, feature request"
+assignees: 'daehyoungko'
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+Describe the Asset Harvester workflow limitation or use case. For example: I need Asset Harvester to export [asset format or metadata] for [simulation workflow].
+
+**Describe the solution you'd like**
+Describe the proposed behavior, including the affected pipeline stage, expected inputs and outputs, and any desired CLI or Python interface.
+
+**Describe alternatives you've considered**
+Describe any existing Asset Harvester options, conversion scripts, manual steps, or external tools you have tried.
+
+**Additional context**
+Add sample inputs, expected Gaussian-splat or metadata outputs, performance requirements, code examples, or references to similar implementations.

--- a/README.md
+++ b/README.md
@@ -17,15 +17,6 @@ To address this challenge, we present Asset Harvester, an image-to-3D model and 
 Rather than relying on a single model component, we developed a system-level design for real-world AV data that combines large-scale curation of object-centric training tuples, geometry-aware preprocessing across heterogeneous sensors, and a robust training recipe that couples sparse-view-conditioned multiview generation with 3D Gaussian lifting. Within this system, SparseViewDiT is explicitly designed to address limited-angle views and other real-world data challenges.
 Together with hybrid data curation, augmentation, and self-distillation, this system enables scalable conversion of sparse AV object observations into reusable 3D assets.
 
-## Support
-
-📣 **Asset Harvester usage questions and discussion**: please post on the [NVIDIA Developer Forum (Omniverse / NuRec)](https://forums.developer.nvidia.com/c/omniverse/platform/nurec/752).
-
-🐛 **Asset Harvester code-level bugs, documentation issues, and feature requests**: file a [GitHub issue](../../issues/new/choose) using the appropriate template (Bug report, Documentation request, or Feature request). The relevant NVIDIA responder is auto-assigned via the `assignees:` field on the template.
-
-🚨 **Security vulnerabilities**: please use [NVIDIA's Vulnerability Disclosure Program](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail). Do not file security issues publicly here.
-
-
 <p align="center">
   <img src="docs/assets/teaser.gif" alt="Asset Harvester teaser" width="100%" style="border: none;">
 </p>
@@ -260,6 +251,14 @@ asset-harvester/
 ## License
 
 This project is licensed under the Apache License 2.0. See individual file headers for details.
+
+## Support
+
+📣 **Asset Harvester usage questions and discussion**: please post on the [NVIDIA Developer Forum (Omniverse / NuRec)](https://forums.developer.nvidia.com/c/omniverse/platform/nurec/752).
+
+🐛 **Asset Harvester code-level bugs, documentation issues, and feature requests**: file a [GitHub issue](../../issues/new/choose) using the appropriate template (Bug report, Documentation request, or Feature request). The relevant NVIDIA responder is auto-assigned via the `assignees:` field on the template.
+
+🚨 **Security vulnerabilities**: please use [NVIDIA's Vulnerability Disclosure Program](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail). Do not file security issues publicly here.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ To address this challenge, we present Asset Harvester, an image-to-3D model and 
 Rather than relying on a single model component, we developed a system-level design for real-world AV data that combines large-scale curation of object-centric training tuples, geometry-aware preprocessing across heterogeneous sensors, and a robust training recipe that couples sparse-view-conditioned multiview generation with 3D Gaussian lifting. Within this system, SparseViewDiT is explicitly designed to address limited-angle views and other real-world data challenges.
 Together with hybrid data curation, augmentation, and self-distillation, this system enables scalable conversion of sparse AV object observations into reusable 3D assets.
 
+## Support
+
+📣 **Asset Harvester usage questions and discussion**: please post on the [NVIDIA Developer Forum (Omniverse / NuRec)](https://forums.developer.nvidia.com/c/omniverse/platform/nurec/752).
+
+🐛 **Asset Harvester code-level bugs, documentation issues, and feature requests**: file a [GitHub issue](../../issues/new/choose) using the appropriate template (Bug report, Documentation request, or Feature request). The relevant NVIDIA responder is auto-assigned via the `assignees:` field on the template.
+
+🚨 **Security vulnerabilities**: please use [NVIDIA's Vulnerability Disclosure Program](https://app.intigriti.com/programs/nvidia/nvidiavdp/detail). Do not file security issues publicly here.
+
 
 <p align="center">
   <img src="docs/assets/teaser.gif" alt="Asset Harvester teaser" width="100%" style="border: none;">


### PR DESCRIPTION
## Summary

- add the uniform NuRec issue chooser configuration
- add Asset Harvester-specific bug, documentation, and feature request bodies
- add the README `## Support` banner with Forum, GitHub Issues, and NVIDIA VDP routing

## Why

This gives Asset Harvester users a consistent path for code-level bugs, documentation requests, and feature requests while routing usage questions to the NVIDIA Developer Forum and security reports to NVIDIA's Vulnerability Disclosure Program.

## User impact

The New Issue chooser will expose exactly three templates plus the single **Submit a question** contact link. The repository's existing `SECURITY.md` allows GitHub to add its own security-policy link without duplicating it in `config.yml`.

## README placement

The support banner is placed after `## License` and before `## Citation`, per the repo owner's requested final position.

## Validation

- confirmed the repository had no existing issue templates, question template, or `## Support` banner
- confirmed exactly three `*_template.md` files and one `config.yml`
- confirmed title prefixes are `[BUG]`, `[DOC]`, and `[FEA]`
- confirmed all three templates retain `assignees: 'daehyoungko'`
- confirmed `blank_issues_enabled: false` and exactly one **Submit a question** contact link
- confirmed the deployed files match the approved package and `git diff --check` passes

## Human-only steps

- [x] Confirm `SECURITY.md` routes vulnerability reports to NVIDIA's VDP.
- [ ] Grant `daehyoungko` **Triage** access in repository Settings → Collaborators; otherwise GitHub may silently skip auto-assignment.
- [x] Confirm the README support banner appears after License and before Citation.
- [x] Mark this PR ready for review, then review and merge it.
- [x] After merge, open `/issues/new/choose` and confirm three templates plus the **Submit a question** link and GitHub's security-policy link.
- [ ] File a test issue, confirm `daehyoungko` is auto-assigned/notified, then close the test issue.
